### PR TITLE
Add Add Thermal Noise Algorithm for DoA estimation

### DIFF
--- a/_UI/_web_interface/kraken_web_interface.py
+++ b/_UI/_web_interface/kraken_web_interface.py
@@ -461,6 +461,7 @@ doa_trace_colors =	{
   "DoA Bartlett": "#00B5F7",
   "DoA Capon"   : "rgb(226,26,28)",
   "DoA MEM"     : "#1CA71C",
+  "DoA TNA"     : "rgb(255, 0, 255)",
   "DoA MUSIC"   : "rgb(257,233,111)"
 }
 figure_font_size = 20
@@ -998,6 +999,7 @@ def generate_config_page_layout(webInterface_inst):
                 {'label': 'Bartlett', 'value': 'Bartlett'},
                 {'label': 'Capon'   , 'value': 'Capon'},
                 {'label': 'MEM'     , 'value': 'MEM'},
+                {'label': 'TNA'     , 'value': 'TNA'},
                 {'label': 'MUSIC'   , 'value': 'MUSIC'}
                 ],
         value=webInterface_inst.module_signal_processor.DOA_algorithm, style={"display":"inline-block"},className="field-body")

--- a/_signal_processing/krakenSDR_signal_processor.py
+++ b/_signal_processing/krakenSDR_signal_processor.py
@@ -818,15 +818,22 @@ def DOA_TNA(R, scanning_vectors):
 
     ADSINR = np.zeros(scanning_vectors.shape[1], dtype=np.complex64)
 
-    R_ = R.astype(np.complex64)
+    # TODO: perhaps we can store scanning_vectors in column-major order from the very begining to
+    # avoid such conversion?
     S_ = np.asfortranarray(scanning_vectors)
 
     # --- Calculation ---
     try:
-        R_inv_2 = np.linalg.matrix_power(R_, -2)
+        R_inv_2 = np.linalg.matrix_power(R, -2)
     except:
         print("ERROR: Singular or non-square matrix")
         return np.ones(1, dtype=np.complex64) * -3
+
+    # TODO: it seems like rising correlation matrix to power benefits from added precision.
+    # This might be artifact of the testing and if it is then we can switching the whole
+    # processing chain from double to single precision for considerable performance uplift,
+    # especially on low grade hardware.
+    R_inv_2 = R_inv_2.astype(np.complex64)
 
     for i in range(scanning_vectors.shape[1]):
         S_theta_ = S_[:, i]

--- a/_signal_processing/krakenSDR_signal_processor.py
+++ b/_signal_processing/krakenSDR_signal_processor.py
@@ -824,7 +824,7 @@ def DOA_TNA(R, scanning_vectors):
     # --- Calculation ---
     try:
         R_inv_2 = np.linalg.matrix_power(R_, -2)
-    except np.linalg.LinAlgError:
+    except:
         print("ERROR: Singular or non-square matrix")
         return np.ones(1, dtype=np.complex64) * -3
 

--- a/_signal_processing/krakenSDR_signal_processor.py
+++ b/_signal_processing/krakenSDR_signal_processor.py
@@ -809,9 +809,7 @@ def channelize(processed_signal, freq, decimation_factor, sampling_freq):
 @njit(fastmath=True, cache=True)
 def DOA_TNA(R, scanning_vectors):
     # --> Input check
-    if R.shape[0] != R.shape[1]:
-        print("ERROR: Correlation matrix is not quadratic")
-        return np.ones(1, dtype=np.complex64) * -1
+
     if R.shape[0] != scanning_vectors.shape[0]:
         print(
             "ERROR: Correlation matrix dimension does not match with the antenna array dimension"
@@ -826,8 +824,8 @@ def DOA_TNA(R, scanning_vectors):
     # --- Calculation ---
     try:
         R_inv_2 = np.linalg.matrix_power(R_, -2)
-    except:
-        print("ERROR: Signular matrix")
+    except np.linalg.LinAlgError as e:
+        print(f"ERROR: {e}")
         return np.ones(1, dtype=np.complex64) * -3
 
     for i in range(scanning_vectors.shape[1]):

--- a/_signal_processing/krakenSDR_signal_processor.py
+++ b/_signal_processing/krakenSDR_signal_processor.py
@@ -824,8 +824,8 @@ def DOA_TNA(R, scanning_vectors):
     # --- Calculation ---
     try:
         R_inv_2 = np.linalg.matrix_power(R_, -2)
-    except np.linalg.LinAlgError as e:
-        print(f"ERROR: {e}")
+    except np.linalg.LinAlgError:
+        print("ERROR: Singular or non-square matrix")
         return np.ones(1, dtype=np.complex64) * -3
 
     for i in range(scanning_vectors.shape[1]):


### PR DESCRIPTION
Seems to be quite old superresolution DoA estimation method[1], but should offer better resolution than Capon's one, yet without prior knowledge of number of rf sources. The change is self-contained, without touching any other parts of the signal processing chain. I outlined possible performance optimizations, but proper regression testing is needed before implementing those outside TNA. The comparison of MUSIC, Capon and TNA for 434 MHz and 868 MHz test signals is shown in the following screenshot:

![image](https://user-images.githubusercontent.com/2339291/182594266-a5b05848-98dc-4729-adda-fe9c8e74a148.png)


[1] W. F. Gabriel, "Spectral analysis and adaptive array superresolution techniques.", Proc. IEEE 68.6 (1980): 654-666.
[2] Y. Naors, M. Moskalets, and S. Teplitskaya, "The analysis of methods for determining direction of arrival of signals in problems of space-time access.", East.-Eur. J. Enterp. Technol. 4 (9) (2016): 36-44.