### PR TITLE
Fix steering vector calculation

### DIFF
--- a/_UI/_web_interface/kraken_web_interface.py
+++ b/_UI/_web_interface/kraken_web_interface.py
@@ -1744,6 +1744,12 @@ def update_daq_params(input_value, f0, gain):
     if webInterface_inst.module_signal_processor.run_processing:
         webInterface_inst.daq_center_freq = f0
         webInterface_inst.config_daq_rf(f0,gain)
+        
+        for i in range(webInterface_inst.module_signal_processor.max_vfos):
+            webInterface_inst.module_signal_processor.vfo_freq[i] = f0
+            app.push_mods({
+                f"vfo_{i}_freq" : {'value': f0}
+            })
 
         wavelength = 300 / webInterface_inst.daq_center_freq
         #webInterface_inst.module_signal_processor.DOA_inter_elem_space = webInterface_inst.ant_spacing_meters / wavelength


### PR DESCRIPTION
Steering vectors depend on the frequency of the signal-of-interest, but not on the central frequency of a DAQ as it is now. So lets compensate for the discrepancy. Also, for convenience lets set VFOs frequencies to the central one on receiver parameters update. This is rather quick&dirty solution made to minimize an impact on the codebase.