### PR TITLE
Add a few decorrelation methods

### DIFF
--- a/_UI/_web_interface/kraken_web_interface.py
+++ b/_UI/_web_interface/kraken_web_interface.py
@@ -98,6 +98,10 @@ DECORRELATION_OPTIONS = [
         'label': 'Spatial Smoothing',
         'value': 'FBSS'
     },
+    {
+        'label': 'F-B Toeplitz',
+        'value': 'FBTOEP'
+    },
 ]
 
 class webInterface():

--- a/_UI/_web_interface/kraken_web_interface.py
+++ b/_UI/_web_interface/kraken_web_interface.py
@@ -94,6 +94,10 @@ DECORRELATION_OPTIONS = [
         'label': 'Toeplizification',
         'value': 'TOEP'
     },
+    {
+        'label': 'Spatial Smoothing',
+        'value': 'FBSS'
+    },
 ]
 
 class webInterface():

--- a/_UI/_web_interface/tooltips.py
+++ b/_UI/_web_interface/tooltips.py
@@ -101,9 +101,9 @@ dsp_config_tooltips = html.Div([
     #        ),
     # Enable F-B averaging
     dbc.Tooltip([
-        html.P("Forward-backward averaging improves the performance of DoA estimation in multipath environments"),
+        html.P("Decorrelation methods that might improve performance of DoA estimation in multipath and (or) low SNR environments."),
         html.P("(Available only for ULA antenna arrays)")],
-        target="label_en_fb_avg",
+        target="label_decorrelation",
         placement="bottom",
         className="tooltip"
     ),

--- a/_signal_processing/krakenSDR_signal_processor.py
+++ b/_signal_processing/krakenSDR_signal_processor.py
@@ -574,8 +574,12 @@ class SignalProcessor(threading.Thread):
             R = de.forward_backward_avg(R)
         elif self.DOA_decorrelation_method == 'TOEP':
             R = toeplitzify(R)
+        elif self.DOA_decorrelation_method == 'FBSS':
+            R = de.spatial_smoothing(processed_signal.T,
+                                     self.channel_number - 1,
+                                     "forward-backward")
 
-        M = self.channel_number
+        M = R.shape[0]
         scanning_vectors = []
         frq_ratio = vfo_freq / self.module_receiver.daq_center_freq
         if self.DOA_ant_alignment == "UCA" or self.DOA_ant_alignment == "ULA":

--- a/settings.json
+++ b/settings.json
@@ -11,7 +11,7 @@
   "custom_array_y_meters": "0.00,-0.20,-0.12,0.12,0.20",
   "array_offset": 0,
   "doa_method": "MUSIC",
-  "en_fbavg": false,
+  "doa_decorrelation_method": "Off",
   "compass_offset": 0,
   "doa_fig_type": "Linear",
   "en_peak_hold": false,


### PR DESCRIPTION
In addition to forward-backward averaging decorrelation method, lets add a few more options:

- forward-backward spatial smoothing;
- Toeplizification (also known as "rectification");
- forward-backward Toeplitz reconstruction.

These might be particularly useful in multi-path environments and (or) low SNR situations. The GUI is also adjusted in the following way to support the new options:

![image](https://user-images.githubusercontent.com/2339291/224334293-fd82b1e7-4565-46e0-bb59-6e06dea24c27.png)
