### PR TITLE
Add phase mode expansion transformation for UCA

### DIFF
--- a/_UI/_web_interface/tooltips.py
+++ b/_UI/_web_interface/tooltips.py
@@ -101,8 +101,7 @@ dsp_config_tooltips = html.Div([
     #        ),
     # Enable F-B averaging
     dbc.Tooltip([
-        html.P("Decorrelation methods that might improve performance of DoA estimation in multipath and (or) low SNR environments."),
-        html.P("(Available only for ULA antenna arrays)")],
+        html.P("Decorrelation methods that might improve performance of DoA estimation in multipath and (or) low SNR environments.")],
         target="label_decorrelation",
         placement="bottom",
         className="tooltip"


### PR DESCRIPTION
The phase mode expansion transformation turns UCA array into Virtual Uniform Linear Array (VULA). It's correlation matrix obeys Vandermonde structure [1] that, thereby, unlocks various signal de-correlation and DoA estimation methods that are typically unavailable for UCA. At the moment, if any of the de-correlation methods is requested for UCA, the phase mode expansion transformation is automatically applied to the input signal.

[1] A. H. Tewfik and W. Hong, "On the application of uniform linear array bearing estimation techniques to uniform circular arrays", IEEE Transactions on Signal Processing, vol. 40, no. 4, pp. 1008-1011, April 1992, doi: 10.1109/78.127980.