### PR TITLE
Improve logging

### DIFF
--- a/_UI/_web_interface/kraken_web_config.py
+++ b/_UI/_web_interface/kraken_web_config.py
@@ -1,17 +1,27 @@
+import os
 from configparser import ConfigParser
 
-from variables import *
 import dash_core_components as dcc
 import dash_html_components as html
 import ini_checker
 import tooltips
+from variables import (
+    DECORRELATION_OPTIONS,
+    calibration_tack_modes,
+    daq_config_filename,
+    daq_preconfigs_path,
+    option,
+    valid_daq_buffer_sizes,
+    valid_fir_windows,
+    valid_sample_rates,
+)
 
 
 def get_preconfigs(config_files_path):
     parser = ConfigParser()
     preconfigs = []
     preconfigs.append([daq_config_filename, "Current"])
-    for root, dirs, files in os.walk(config_files_path):
+    for root, _, files in os.walk(config_files_path):
         if len(files):
             config_file_path = os.path.join(root, files[0])
             parser.read([config_file_path])
@@ -98,9 +108,6 @@ def generate_config_page_layout(webInterface_inst):
     en_advanced_daq_cfg = [1] if webInterface_inst.en_advanced_daq_cfg else []
     en_basic_daq_cfg = [1] if webInterface_inst.en_basic_daq_cfg else []
     # Calulcate spacings
-    wavelength = 300 / webInterface_inst.daq_center_freq
-    ant_spacing_wavelength = webInterface_inst.module_signal_processor.DOA_inter_elem_space
-    # round(wavelength * ant_spacing_wavelength, 3)
     ant_spacing_meter = webInterface_inst.ant_spacing_meters
 
     decimated_bw = ((daq_cfg_dict["sample_rate"]) / daq_cfg_dict["decimation_ratio"]) / 10**3
@@ -1242,6 +1249,39 @@ def generate_config_page_layout(webInterface_inst):
                     ),
                 ],
                 id="gps_status_info",
+            ),
+            html.Div(
+                [
+                    html.Div(
+                        [
+                            html.Div("Min speed for heading [m/s]:", className="field-label"),
+                            dcc.Input(
+                                id="min_speed_input",
+                                value=webInterface_inst.module_signal_processor.gps_min_speed_for_valid_heading,
+                                type="number",
+                                className="field-body-textbox",
+                                debounce=True,
+                            ),
+                        ],
+                        id="min_speed_field",
+                        className="field",
+                    ),
+                    html.Div(
+                        [
+                            html.Div("Min speed duration for heading [s]", className="field-label"),
+                            dcc.Input(
+                                id="min_speed_duration_input",
+                                value=webInterface_inst.module_signal_processor.gps_min_duration_for_valid_heading,
+                                type="number",
+                                className="field-body-textbox",
+                                debounce=True,
+                            ),
+                        ],
+                        id="min_speed_duration_field",
+                        className="field",
+                    ),
+                ],
+                id="min_speed_heading_fields",
             ),
         ],
         className="card",

--- a/_UI/_web_interface/kraken_web_doa.py
+++ b/_UI/_web_interface/kraken_web_doa.py
@@ -2,11 +2,11 @@ import dash_core_components as dcc
 import dash_html_components as html
 import numpy as np
 import plotly.graph_objects as go
-from variables import *
+from variables import doa_fig, figure_font_size, x, y
 
 
 def plot_doa(app, webInterface_inst, doa_fig):
-    if webInterface_inst.reset_doa_graph_flag == True:
+    if webInterface_inst.reset_doa_graph_flag:
         doa_fig.data = []
         # Just generate with junk data initially, as the spectrum array may not
         # be ready yet if we have sqeulching active etc.
@@ -87,7 +87,6 @@ def plot_doa(app, webInterface_inst, doa_fig):
         webInterface_inst.reset_doa_graph_flag = False
     else:
         update_data = []
-        fig_type = []
         doa_max_str = ""
         if webInterface_inst.doa_thetas is not None and webInterface_inst.doa_results[0].size > 0:
             doa_max_str = str(webInterface_inst.doas[0]) + "°"

--- a/_UI/_web_interface/kraken_web_interface.py
+++ b/_UI/_web_interface/kraken_web_interface.py
@@ -165,6 +165,8 @@ class webInterface:
         self.module_signal_processor.latitude = dsp_settings.get("latitude", 0.0)
         self.module_signal_processor.longitude = dsp_settings.get("longitude", 0.0)
         self.module_signal_processor.heading = dsp_settings.get("heading", 0.0)
+        self.module_signal_processor.gps_min_speed_for_valid_heading=dsp_settings.get("gps_min_speed", 2)
+        self.module_signal_processor.gps_min_duration_for_valid_heading=dsp_settings.get("gps_min_speed_duration", 3)
 
         # Kraken Pro Remote Key
         self.module_signal_processor.krakenpro_key = dsp_settings.get("krakenpro_key", 0.0)
@@ -306,6 +308,8 @@ class webInterface:
         data["heading"] = self.module_signal_processor.heading
         data["krakenpro_key"] = self.module_signal_processor.krakenpro_key
         data["rdf_mapper_server"] = self.module_signal_processor.RDF_mapper_server
+        data["gps_min_speed"] = self.module_signal_processor.gps_min_speed_for_valid_heading
+        data["gps_min_speed_duration"] = self.module_signal_processor.gps_min_duration_for_valid_heading
 
         # VFO Information
         data["spectrum_calculation"] = self.module_signal_processor.spectrum_fig_type

--- a/_UI/_web_interface/kraken_web_interface.py
+++ b/_UI/_web_interface/kraken_web_interface.py
@@ -20,17 +20,33 @@
 
 import json
 import logging
+import os
 import queue
 import subprocess
 import time
-from configparser import ConfigParser
 from threading import Timer
 
 import dash_core_components as dcc
 import dash_devices as dash
 import dash_html_components as html
 import numpy as np
-import plotly.graph_objects as go
+
+# isort: off
+from variables import (
+    DECORRELATION_OPTIONS,
+    trace_colors,
+    doa_fig,
+    root_path,
+    fig_layout,
+    daq_config_filename,
+    current_path,
+    daq_subsystem_path,
+    daq_stop_filename,
+    daq_start_filename,
+)
+
+# isort: on
+
 from dash_devices.dependencies import Input, Output, State
 from kraken_web_config import generate_config_page_layout, write_config_file_dict
 from kraken_web_doa import generate_doa_page_layout, plot_doa
@@ -39,8 +55,7 @@ from krakenSDR_receiver import ReceiverRTLSDR
 
 # Import built-in modules
 from krakenSDR_signal_processor import SignalProcessor, xi
-from utils import *
-from variables import *
+from utils import read_config_file_dict, set_clicked
 from waterfall import init_waterfall
 
 # Load settings file
@@ -591,7 +606,6 @@ def settings_change_watcher():
         center_freq = float(dsp_settings.get("center_freq", 100.0))
         gain = float(dsp_settings.get("uniform_gain", 1.4))
 
-        DOA_ant_alignment = dsp_settings.get("ant_arrangement")
         webInterface_inst.ant_spacing_meters = float(dsp_settings.get("ant_spacing_meters", 0.5))
 
         webInterface_inst.module_signal_processor.en_DOA_estimation = dsp_settings.get("en_doa", 0)
@@ -931,32 +945,30 @@ def toggle_gps_fields(toggle_value):
 
 
 # Enable of Disable Kraken Pro Key Box
-
-
-@app.callback(Output("krakenpro_field", "style"), [Input("doa_format_type", "value")])
+@app.callback(
+    [Output("krakenpro_field", "style"), Output("rdf_mapper_server_address_field", "style")],
+    [Input("doa_format_type", "value")],
+)
 def toggle_kraken_pro_key(doa_format_type):
-    if doa_format_type == "Kraken Pro Remote":
-        return {"display": "block"}
-    else:
-        return {"display": "none"}
-
-
-# Enable of Disable Kraken Pro Key Box
-@app.callback(Output("rdf_mapper_server_address_field", "style"), [Input("doa_format_type", "value")])
-def toggle_kraken_pro_key(doa_format_type):
-    if doa_format_type == "RDF Mapper" or doa_format_type == "Full POST":
-        return {"display": "block"}
-    else:
-        return {"display": "none"}
+    kraken_pro_field_style = {"display": "block"} if doa_format_type == "Kraken Pro Remote" else {"display": "none"}
+    rdf_mapper_server_address_field_style = (
+        {"display": "block"}
+        if doa_format_type == "RDF Mapper" or doa_format_type == "Full POST"
+        else {"display": "none"}
+    )
+    return kraken_pro_field_style, rdf_mapper_server_address_field_style
 
 
 # Enable or Disable Heading Input Fields
 @app.callback(
     Output("heading_field", "style"),
-    [Input("loc_src_dropdown", "value"), Input(component_id="fixed_heading_check", component_property="value")],
+    [
+        Input("loc_src_dropdown", "value"),
+        Input(component_id="fixed_heading_check", component_property="value"),
+    ],
     [State("heading_input", component_property="value")],
 )
-def toggle_location_info(static_loc, fixed_heading, heading):
+def toggle_heading_info(static_loc, fixed_heading, heading):
     if static_loc == "Static":
         webInterface_inst.module_signal_processor.fixed_heading = True
         webInterface_inst.module_signal_processor.heading = heading
@@ -979,6 +991,19 @@ def toggle_location_info(static_loc, fixed_heading, heading):
 def toggle_location_info(toggle_value):
     webInterface_inst.location_source = toggle_value
     if toggle_value == "Static":
+        return {"display": "block"}
+    else:
+        return {"display": "none"}
+
+
+# Enable or Disable Location Input Fields
+@app.callback(
+    Output("min_speed_heading_fields", "style"),
+    [Input("loc_src_dropdown", "value"), Input("fixed_heading_check", "value")],
+)
+def toggle_min_speed_heading_filter(toggle_value, fixed_heading):
+    webInterface_inst.location_source = toggle_value
+    if toggle_value == "gpsd" and not fixed_heading:
         return {"display": "block"}
     else:
         return {"display": "none"}
@@ -1012,13 +1037,27 @@ def set_fixed_heading(fixed):
 
 # Set heading data
 @app.callback_shared(None, [Input(component_id="heading_input", component_property="value")])
-def set_static_location(heading):
+def set_static_heading(heading):
     webInterface_inst.module_signal_processor.heading = heading
 
 
-# Enable GPS (note that we need this to fire on load, so we cannot use
-# callback_shared!)
-@app.callback([Output("gps_status", "children"), Output("gps_status", "style")], [Input("loc_src_dropdown", "value")])
+# Set minimum speed for trustworthy GPS heading
+@app.callback_shared(None, [Input(component_id="min_speed_input", component_property="value")])
+def set_min_speed_for_valid_gps_heading(min_speed):
+    webInterface_inst.module_signal_processor.gps_min_speed_for_valid_heading = min_speed
+
+
+# Set minimum speed duration for trustworthy GPS heading
+@app.callback_shared(None, [Input(component_id="min_speed_duration_input", component_property="value")])
+def set_min_speed_duration_for_valid_gps_heading(min_speed_duration):
+    webInterface_inst.module_signal_processor.gps_min_duration_for_valid_heading = min_speed_duration
+
+
+# Enable GPS (note that we need this to fire on load, so we cannot use callback_shared!)
+@app.callback(
+    [Output("gps_status", "children"), Output("gps_status", "style")],
+    [Input("loc_src_dropdown", "value")],
+)
 def enable_gps(toggle_value):
     if toggle_value == "gpsd":
         status = webInterface_inst.module_signal_processor.enable_gps()
@@ -1150,7 +1189,7 @@ def restart_sw_btn(input_value):
     webInterface_inst.logger.info("Restarting Software")
     root_path = os.path.dirname(os.path.dirname(os.path.dirname(current_path)))
     os.chdir(root_path)
-    daq_start_script = subprocess.Popen(["bash", "kraken_doa_start.sh"])  # ,
+    subprocess.Popen(["bash", "kraken_doa_start.sh"])  # ,
 
 
 @app.callback_shared(
@@ -1179,7 +1218,7 @@ def clear_cache_btn(input_value):
     webInterface_inst.logger.info("Clearing Python and Numba Caches")
     root_path = os.path.dirname(os.path.dirname(os.path.dirname(current_path)))
     os.chdir(root_path)
-    daq_start_script = subprocess.Popen(["bash", "kraken_doa_start.sh", "-c"])  # ,
+    subprocess.Popen(["bash", "kraken_doa_start.sh", "-c"])  # ,
 
 
 @app.callback_shared(None, [Input("spectrum-graph", "clickData")])
@@ -1301,7 +1340,9 @@ def update_dsp_params(
             np.rad2deg(2 * np.pi * max_phase_diff)
         )
     elif max_phase_diff < 0.1:
-        ambiguity_warning = "WARNING: Array size may be too small.".format(np.rad2deg(2 * np.pi * max_phase_diff))
+        ambiguity_warning = "WARNING: Array size may be too small.  Max phase difference: {:.1f}°.".format(
+            np.rad2deg(2 * np.pi * max_phase_diff)
+        )
     else:
         ambiguity_warning = ""
 

--- a/_UI/_web_interface/kraken_web_interface.py
+++ b/_UI/_web_interface/kraken_web_interface.py
@@ -165,8 +165,8 @@ class webInterface:
         self.module_signal_processor.latitude = dsp_settings.get("latitude", 0.0)
         self.module_signal_processor.longitude = dsp_settings.get("longitude", 0.0)
         self.module_signal_processor.heading = dsp_settings.get("heading", 0.0)
-        self.module_signal_processor.gps_min_speed_for_valid_heading=dsp_settings.get("gps_min_speed", 2)
-        self.module_signal_processor.gps_min_duration_for_valid_heading=dsp_settings.get("gps_min_speed_duration", 3)
+        self.module_signal_processor.gps_min_speed_for_valid_heading = dsp_settings.get("gps_min_speed", 2)
+        self.module_signal_processor.gps_min_duration_for_valid_heading = dsp_settings.get("gps_min_speed_duration", 3)
 
         # Kraken Pro Remote Key
         self.module_signal_processor.krakenpro_key = dsp_settings.get("krakenpro_key", 0.0)

--- a/_UI/_web_interface/kraken_web_spectrum.py
+++ b/_UI/_web_interface/kraken_web_spectrum.py
@@ -1,7 +1,7 @@
 import numpy as np
 import plotly.express as px
 import plotly.graph_objects as go
-from variables import *
+from variables import figure_font_size, trace_colors, x, y
 
 
 def init_spectrum_fig(webInterface_inst, fig_layout, trace_colors):
@@ -56,7 +56,7 @@ def init_spectrum_fig(webInterface_inst, fig_layout, trace_colors):
 
     # Now add the angle display text
     # webInterface_inst.module_signal_processor.active_vfos):
-    for i in range(webInterface_inst.module_signal_processor.max_vfos):
+    for _ in range(webInterface_inst.module_signal_processor.max_vfos):
         spectrum_fig.add_annotation(
             x=415640000,
             y=-5,

--- a/_UI/_web_interface/tooltips.py
+++ b/_UI/_web_interface/tooltips.py
@@ -633,5 +633,20 @@ station_parameters_tooltips = html.Div(
             placement="bottom",
             className="tooltip",
         ),
+        dbc.Tooltip(
+            [
+                html.P("Filter out unreliable heading"),
+                html.P("Most consumer-grade GPS modules require it to move to estimate heading."),
+                html.P("Typically those measurements are not reliable when speed is too low."),
+                html.P("Please set minimum speed and its minumum duration to filter out bogus heading readings."),
+                html.P(
+                    """Note that u-blox GPS modules might implement these logic internally, but it needs to be configured and activated."""
+                    """If you did so, then feel free to disable this filter by setting zero values."""
+                ),
+            ],
+            target="min_speed_heading_fields",
+            placement="bottom",
+            className="tooltip",
+        ),
     ]
 )

--- a/_UI/_web_interface/waterfall.py
+++ b/_UI/_web_interface/waterfall.py
@@ -1,5 +1,5 @@
 import plotly.graph_objects as go
-from variables import *
+from variables import fig_layout
 
 
 def init_waterfall(webInterface_inst):

--- a/_receiver/krakenSDR_receiver.py
+++ b/_receiver/krakenSDR_receiver.py
@@ -82,7 +82,7 @@ class ReceiverRTLSDR:
         self.ctr_iface_thread_lock = Lock()  # Used to synchronize the operation of the ctr_iface thread
 
         self.iq_frame_bytes = None
-        self.iq_samples = None
+        self.iq_samples = np.empty(0)
         self.iq_header = IQHeader()
         self.M = 0  # Number of receiver channels, updated after establishing connection
 

--- a/_signal_processing/krakenSDR_signal_processor.py
+++ b/_signal_processing/krakenSDR_signal_processor.py
@@ -956,7 +956,7 @@ class SignalProcessor(threading.Thread):
         jsonDict["processing_time"] = self.processing_time
         jsonDict["doaArray"] = doaString
         jsonDict["adc_overdrive"] = adc_overdrive
-        jsonDict["num_corr_sources"] = num_corr_sources
+        jsonDict["num_corr_sources"] = str(num_corr_sources)
         jsonDict["snr_db"] = snr_db
 
         try:

--- a/_signal_processing/krakenSDR_signal_processor.py
+++ b/_signal_processing/krakenSDR_signal_processor.py
@@ -27,6 +27,7 @@ import os
 import threading
 import time
 import xml.etree.ElementTree as ET
+from datetime import datetime
 from functools import lru_cache
 from multiprocessing.dummy import Pool
 from typing import Tuple
@@ -58,6 +59,9 @@ try:
 except ModuleNotFoundError:
     hasgps = False
     print("Can't find gpsd - ok if no external gps used")
+
+MIN_SPEED_FOR_VALID_HEADING = 2.0  # m / s
+MIN_DURATION_FOR_VALID_HEADING = 3.0  # s
 
 
 class SignalProcessor(threading.Thread):
@@ -135,6 +139,9 @@ class SignalProcessor(threading.Thread):
         self.en_peak_hold = False
 
         self.latency = 100
+        self.processing_time = 0
+        self.timestamp = int(time.time() * 1000)
+        self.gps_timestamp = int(0)
 
         # Output Data format. XML for Kerberos, CSV for Kracken, JSON future
         self.DOA_data_format = "Kraken App"  # XML, CSV, or JSON
@@ -146,17 +153,26 @@ class SignalProcessor(threading.Thread):
         self.longitude = 0.0
         self.fixed_heading = False
         self.heading = 0.0
+        self.time_of_last_invalid_heading = time.time()
         self.altitude = 0.0
         self.speed = 0.0
         self.hasgps = hasgps
         self.usegps = False
+        self.gps_min_speed_for_valid_heading = MIN_SPEED_FOR_VALID_HEADING
+        self.gps_min_duration_for_valid_heading = MIN_DURATION_FOR_VALID_HEADING
         self.gps_connected = False
         self.krakenpro_key = "0"
         self.RDF_mapper_server = "http://MY_RDF_MAPPER_SERVER.com/save.php"
         self.full_rest_server = "http://MY_REST_SERVER.com/save.php"
         self.pool = Pool()
-        self.rdf_mapper_last_write_time = 0
+        self.rdf_mapper_last_write_time = time.time()
         self.doa_max_list = [-1] * self.max_vfos
+
+        self.theta_0_list = []
+        self.freq_list = []
+        self.doa_result_log_list = []
+        self.confidence_list = []
+        self.max_power_level_list = []
 
         # TODO: NEED to have a funtion to update the file name if changed in the web ui
         self.data_recording_file_name = "mydata.csv"
@@ -164,7 +180,12 @@ class SignalProcessor(threading.Thread):
         self.data_record_fd = open(data_recording_file_path, "a+")
         self.en_data_record = False
         self.write_interval = 1
-        self.last_write_time = [0] * self.max_vfos
+        self.last_write_time = [time.time()] * self.max_vfos
+
+        self.adc_overdrive = False
+        self.number_of_correlated_sources = []
+        self.snrs = []
+        self.dropped_frames = 0
 
     def resetPeakHold(self):
         if self.spectrum_fig_type == "Single":
@@ -187,8 +208,18 @@ class SignalProcessor(threading.Thread):
                 self.is_running = True
                 que_data_packet = []
 
+                utc_timestamp_ms = datetime.utcfromtimestamp(
+                    self.module_receiver.iq_header.time_stamp / 1000.0
+                ).timestamp()
+                self.timestamp = int(round(1000.0 * utc_timestamp_ms))
+
+                if self.hasgps and self.usegps:
+                    self.update_location_and_timestamp()
+
                 # -----> ACQUIRE NEW DATA FRAME <-----
                 self.module_receiver.get_iq_online()
+                self.adc_overdrive = self.module_receiver.iq_header.adc_overdrive_flags
+
                 start_time = time.time()
 
                 # Check frame type for processing
@@ -214,10 +245,16 @@ class SignalProcessor(threading.Thread):
 
                 self.data_ready = False
 
-                if en_proc:
-                    self.processed_signal = np.ascontiguousarray(
-                        self.module_receiver.iq_samples
-                    )  # self.module_receiver.iq_samples.copy()
+                if en_proc and not self.module_receiver.iq_samples.size:
+                    if self.dropped_frames:
+                        logging.error(
+                            """The data frame was lost while processing was active!\n
+                            This might indicate issues with USB data cable or USB host,\n
+                            inadequate power supply, overloaded CPU, wrong host OS settings, etc."""
+                        )
+                    self.dropped_frames += 1
+                elif en_proc:
+                    self.processed_signal = np.ascontiguousarray(self.module_receiver.iq_samples)
                     sampling_freq = self.module_receiver.iq_header.sampling_freq
 
                     global_decimation_factor = max(
@@ -306,14 +343,15 @@ class SignalProcessor(threading.Thread):
                             DOA_str = ""
                             confidence_str = ""
                             max_power_level_str = ""
-                            doa_result_log = np.array([])
+                            doa_result_log = np.empty(0)
 
-                            theta_0_list = []
-                            DOA_str_list = []
-                            confidence_str_list = []
-                            max_power_level_str_list = []
-                            freq_list = []
-                            doa_result_log_list = []
+                            self.theta_0_list.clear()
+                            self.freq_list.clear()
+                            self.doa_result_log_list.clear()
+                            self.max_power_level_list.clear()
+                            self.confidence_list.clear()
+                            self.number_of_correlated_sources.clear()
+                            self.snrs.clear()
 
                             for i in range(active_vfos):
                                 # If chanenl freq is out of bounds for the current tuned bandwidth, reset to the middle freq
@@ -420,200 +458,18 @@ class SignalProcessor(threading.Thread):
                                     confidence_str = "{:.2f}".format(np.max(conf_val))
                                     max_power_level_str = "{:.1f}".format((np.maximum(-100, max_amplitude)))
 
-                                    theta_0_list.append(theta_0)
-                                    DOA_str_list.append(DOA_str)
-                                    confidence_str_list.append(confidence_str)
-                                    max_power_level_str_list.append(max_power_level_str)
-                                    freq_list.append(write_freq)
-                                    doa_result_log_list.append(doa_result_log)
+                                    self.theta_0_list.append(theta_0)
+                                    self.confidence_list.append(np.max(conf_val))
+                                    self.max_power_level_list.append(np.maximum(-100, max_amplitude))
+                                    self.freq_list.append(write_freq)
+                                    self.doa_result_log_list.append(doa_result_log)
 
                             que_data_packet.append(["doa_thetas", self.DOA_theta])
                             que_data_packet.append(["DoA Result", doa_result_log])
                             que_data_packet.append(["DoA Max", theta_0])
                             que_data_packet.append(["DoA Confidence", conf_val])
                             que_data_packet.append(["DoA Squelch", update_list])
-
-                            # Do Kraken App first as currently its the only one supporting multi-vfo out
-                            if (
-                                self.DOA_data_format == "Kraken App"
-                                or self.en_data_record
-                                or self.DOA_data_format == "Kraken Pro Local"
-                                or self.DOA_data_format == "Kraken Pro Remote"
-                                or self.DOA_data_format == "RDF Mapper"
-                                or self.DOA_data_format == "DF Aggregator"
-                                or self.DOA_data_format == "Full POST"
-                            ):  # and len(freq_list) > 0:
-                                epoch_time = int(time.time() * 1000)
-                                message = ""
-                                for j in range(len(freq_list)):
-                                    # KrakenSDR Android App Output
-                                    sub_message = ""
-                                    sub_message += f"{epoch_time}, {DOA_str_list[j]}, {confidence_str_list[j]}, {max_power_level_str_list[j]}, "
-                                    sub_message += (
-                                        f"{freq_list[j]}, {self.DOA_ant_alignment}, {self.latency}, {self.station_id}, "
-                                    )
-                                    sub_message += (
-                                        f"{self.latitude}, {self.longitude}, {self.heading}, {self.heading}, "
-                                    )
-                                    sub_message += "GPS, R, R, R, R"  # Reserve 6 entries for other things # NOTE: Second heading is reserved for GPS heading / compass heading differentiation
-
-                                    doa_result_log = doa_result_log_list[j] + np.abs(np.min(doa_result_log_list[j]))
-                                    for i in range(len(doa_result_log)):
-                                        sub_message += ", " + "{:.2f}".format(doa_result_log[i])
-
-                                    sub_message += " \n"
-
-                                    if self.en_data_record:
-                                        time_elapsed = (
-                                            time.time() - self.last_write_time[j]
-                                        )  # Make a list of 16 last_write_times
-                                        if time_elapsed > self.write_interval:
-                                            self.last_write_time[j] = time.time()
-                                            self.data_record_fd.write(sub_message)
-
-                                    message += sub_message
-
-                                if (
-                                    self.DOA_data_format == "Kraken App"
-                                    or self.DOA_data_format == "Kraken Pro Local"
-                                    or self.DOA_data_format == "Kraken Pro Remote"
-                                    or self.DOA_data_format == "RDF Mapper"
-                                    or self.DOA_data_format == "DF Aggregator"
-                                    or self.DOA_data_format == "Full POST"
-                                ):
-                                    self.DOA_res_fd.seek(0)
-                                    self.DOA_res_fd.write(message)
-                                    self.DOA_res_fd.truncate()
-
-                            # Now create output for apps that only take one VFO
-                            DOA_str = str(int(theta_0))
-                            confidence_str = "{:.2f}".format(np.max(conf_val))
-                            max_power_level_str = "{:.1f}".format((np.maximum(-100, max_amplitude)))
-
-                            # Outside the foor loop at this indent
                             que_data_packet.append(["DoA Max List", self.doa_max_list])
-
-                            if self.DOA_data_format == "DF Aggregator":
-                                self.wr_xml(
-                                    self.station_id,
-                                    DOA_str,
-                                    confidence_str,
-                                    max_power_level_str,
-                                    write_freq,
-                                    self.latitude,
-                                    self.longitude,
-                                    self.heading,
-                                )
-                            elif self.DOA_data_format == "Kerberos App":
-                                self.wr_csv(
-                                    self.station_id,
-                                    DOA_str,
-                                    confidence_str,
-                                    max_power_level_str,
-                                    write_freq,
-                                    doa_result_log,
-                                    self.latitude,
-                                    self.longitude,
-                                    self.heading,
-                                    "Kerberos",
-                                )
-                            elif self.DOA_data_format == "Kraken Pro Local":
-                                self.wr_json(
-                                    self.station_id,
-                                    DOA_str,
-                                    confidence_str,
-                                    max_power_level_str,
-                                    write_freq,
-                                    doa_result_log,
-                                    self.latitude,
-                                    self.longitude,
-                                    self.heading,
-                                )
-                            elif self.DOA_data_format == "Kraken Pro Remote":
-                                self.wr_json(
-                                    self.station_id,
-                                    DOA_str,
-                                    confidence_str,
-                                    max_power_level_str,
-                                    write_freq,
-                                    doa_result_log,
-                                    self.latitude,
-                                    self.longitude,
-                                    self.heading,
-                                )
-                            elif self.DOA_data_format == "RDF Mapper":
-                                epoch_time = int(time.time() * 1000)
-
-                                time_elapsed = time.time() - self.rdf_mapper_last_write_time
-                                if (
-                                    time_elapsed > 1
-                                ):  # Upload to RDF Mapper server only every 1s to ensure we dont overload his server
-                                    self.rdf_mapper_last_write_time = time.time()
-                                    elat, elng = calculate_end_lat_lng(
-                                        self.latitude,
-                                        self.longitude,
-                                        int(DOA_str),
-                                        self.heading,
-                                    )
-                                    rdf_post = {
-                                        "id": self.station_id,
-                                        "time": str(epoch_time),
-                                        "slat": str(self.latitude),
-                                        "slng": str(self.longitude),
-                                        "elat": str(elat),
-                                        "elng": str(elng),
-                                    }
-                                    try:
-                                        # out = requests.post(self.RDF_mapper_server, data = rdf_post, timeout=5)
-                                        self.pool.apply_async(
-                                            requests.post,
-                                            args=[self.RDF_mapper_server, rdf_post],
-                                        )
-                                    except Exception as e:
-                                        print(f"NO CONNECTION: Invalid RDF Mapper Server: {e}")
-                            elif self.DOA_data_format == "Full POST":
-                                epoch_time = int(time.time() * 1000)
-
-                                time_elapsed = time.time() - self.rdf_mapper_last_write_time
-                                if time_elapsed > 1:  # reuse RDF mapper timer, it works the same
-                                    self.rdf_mapper_last_write_time = time.time()
-
-                                    message = ""
-                                    if doa_result_log:
-                                        doa_result_log = doa_result_log + np.abs(np.min(doa_result_log))
-                                        for i in range(len(doa_result_log)):
-                                            message += ", " + "{:.2f}".format(doa_result_log[i])
-
-                                    post = {
-                                        "id": self.station_id,
-                                        "ip": myip,
-                                        "time": str(epoch_time),
-                                        "lat": str(self.latitude),
-                                        "lng": str(self.longitude),
-                                        "gpsheading": str(self.heading),
-                                        "radiobearing": DOA_str,
-                                        "conf": confidence_str,
-                                        "power": max_power_level_str,
-                                        "freq": str(write_freq),
-                                        "anttype": self.DOA_ant_alignment,
-                                        "latency": str(self.latency),
-                                        "doaarray": message,
-                                    }
-                                    try:
-                                        # out = requests.post(self.RDF_mapper_server, data = rdf_post, timeout=5)
-                                        self.pool.apply_async(
-                                            requests.post,
-                                            args=[self.RDF_mapper_server, post],
-                                        )
-                                    except Exception as e:
-                                        print(f"NO CONNECTION: Invalid Server: {e}")
-                            elif self.DOA_data_format == "Kraken App":
-                                pass  # Just do nothing, stop the invalid doa result error from showing
-                            else:
-                                self.logger.error(f"Invalid DOA Result data format: {self.DOA_data_format}")
-
-                            if self.hasgps and self.usegps:
-                                self.update_location()
                     except Exception:
                         self.data_ready = False
 
@@ -631,7 +487,191 @@ class SignalProcessor(threading.Thread):
                             "Saving IQ samples to npy is obsolete, IQ Frame saving is currently not implemented"
                         )
 
+                    daq_cpi = int(
+                        self.module_receiver.iq_header.cpi_length * 1000 / self.module_receiver.iq_header.sampling_freq
+                    )
+                    # We don't include processing latency here, because reported timestamp marks end of the data frame
+                    # so latency is essentially an acquisition time.
+                    self.latency = daq_cpi
+                    self.processing_time = int(1000 * (time.time() - start_time))
+
+                    if self.data_ready and self.theta_0_list:
+                        # Do Kraken App first as currently its the only one supporting multi-vfo out
+                        if (
+                            self.DOA_data_format == "Kraken App"
+                            or self.en_data_record
+                            or self.DOA_data_format == "Kraken Pro Local"
+                            or self.DOA_data_format == "Kraken Pro Remote"
+                            or self.DOA_data_format == "RDF Mapper"
+                            or self.DOA_data_format == "DF Aggregator"
+                            or self.DOA_data_format == "Full POST"
+                        ):  # and len(freq_list) > 0:
+                            message = ""
+                            for j, freq in enumerate(self.freq_list):
+                                # KrakenSDR Android App Output
+                                sub_message = ""
+                                sub_message += f"{self.timestamp}, {self.theta_0_list[j]}, {self.confidence_list[j]}, {self.max_power_level_list[j]}, "
+                                sub_message += f"{freq}, {self.DOA_ant_alignment}, {self.latency}, {self.station_id}, "
+                                sub_message += f"{self.latitude}, {self.longitude}, {self.heading}, {self.heading}, "
+                                sub_message += "GPS, R, R, R, R"  # Reserve 6 entries for other things # NOTE: Second heading is reserved for GPS heading / compass heading differentiation
+
+                                doa_result_log = self.doa_result_log_list[j] + np.abs(
+                                    np.min(self.doa_result_log_list[j])
+                                )
+                                for i in range(len(doa_result_log)):
+                                    sub_message += ", " + "{:.2f}".format(doa_result_log[i])
+
+                                sub_message += " \n"
+
+                                if self.en_data_record:
+                                    time_elapsed = (
+                                        time.time() - self.last_write_time[j]
+                                    )  # Make a list of 16 last_write_times
+                                    if time_elapsed > self.write_interval:
+                                        self.last_write_time[j] = time.time()
+                                        self.data_record_fd.write(sub_message)
+
+                                message += sub_message
+
+                            if (
+                                self.DOA_data_format == "Kraken App"
+                                or self.DOA_data_format == "Kraken Pro Local"
+                                or self.DOA_data_format == "Kraken Pro Remote"
+                                or self.DOA_data_format == "RDF Mapper"
+                                or self.DOA_data_format == "DF Aggregator"
+                                or self.DOA_data_format == "Full POST"
+                            ):
+                                self.DOA_res_fd.seek(0)
+                                self.DOA_res_fd.write(message)
+                                self.DOA_res_fd.truncate()
+
+                        # Now create output for apps that only take one VFO
+                        DOA_str = f"{int(self.theta_0_list[0])}"
+                        confidence_str = f"{np.max(self.confidence_list[0]):.2f}"
+                        max_power_level_str = f"{np.maximum(-100, self.max_power_level_list[0]):.1f}"
+                        doa_result_log = self.doa_result_log_list[0]
+                        write_freq = self.freq_list[0]
+
+                        if self.DOA_data_format == "DF Aggregator":
+                            self.wr_xml(
+                                self.station_id,
+                                DOA_str,
+                                confidence_str,
+                                max_power_level_str,
+                                write_freq,
+                                self.latitude,
+                                self.longitude,
+                                self.heading,
+                                self.adc_overdrive,
+                                self.number_of_correlated_sources[0],
+                                self.snrs[0],
+                            )
+                        elif self.DOA_data_format == "Kerberos App":
+                            self.wr_csv(
+                                self.station_id,
+                                DOA_str,
+                                confidence_str,
+                                max_power_level_str,
+                                write_freq,
+                                doa_result_log,
+                                self.latitude,
+                                self.longitude,
+                                self.heading,
+                                "Kerberos",
+                            )
+                        elif self.DOA_data_format == "Kraken Pro Local":
+                            self.wr_json(
+                                self.station_id,
+                                DOA_str,
+                                confidence_str,
+                                max_power_level_str,
+                                write_freq,
+                                doa_result_log,
+                                self.latitude,
+                                self.longitude,
+                                self.heading,
+                                self.adc_overdrive,
+                                self.number_of_correlated_sources[0],
+                                self.snrs[0],
+                            )
+                        elif self.DOA_data_format == "Kraken Pro Remote":
+                            self.wr_json(
+                                self.station_id,
+                                DOA_str,
+                                confidence_str,
+                                max_power_level_str,
+                                write_freq,
+                                doa_result_log,
+                                self.latitude,
+                                self.longitude,
+                                self.heading,
+                                self.adc_overdrive,
+                                self.number_of_correlated_sources[0],
+                                self.snrs[0],
+                            )
+                        elif self.DOA_data_format == "RDF Mapper":
+                            time_elapsed = time.time() - self.rdf_mapper_last_write_time
+                            if (
+                                time_elapsed > 1
+                            ):  # Upload to RDF Mapper server only every 1s to ensure we dont overload his server
+                                self.rdf_mapper_last_write_time = time.time()
+                                elat, elng = calculate_end_lat_lng(
+                                    self.latitude, self.longitude, int(DOA_str), self.heading
+                                )
+                                rdf_post = {
+                                    "id": self.station_id,
+                                    "time": str(self.timestamp),
+                                    "slat": str(self.latitude),
+                                    "slng": str(self.longitude),
+                                    "elat": str(elat),
+                                    "elng": str(elng),
+                                }
+                                try:
+                                    self.pool.apply_async(requests.post, args=[self.RDF_mapper_server, rdf_post])
+                                except Exception as e:
+                                    print(f"NO CONNECTION: Invalid RDF Mapper Server: {e}")
+                        elif self.DOA_data_format == "Full POST":
+                            time_elapsed = time.time() - self.rdf_mapper_last_write_time
+                            if time_elapsed > 1:  # reuse RDF mapper timer, it works the same
+                                self.rdf_mapper_last_write_time = time.time()
+
+                                message = ""
+                                if doa_result_log:
+                                    doa_result_log = doa_result_log + np.abs(np.min(doa_result_log))
+                                    for i in range(len(doa_result_log)):
+                                        message += ", " + "{:.2f}".format(doa_result_log[i])
+
+                                post = {
+                                    "id": self.station_id,
+                                    "ip": myip,
+                                    "time": str(self.timestamp),
+                                    "gps_timestamp": str(self.gps_timestamp),
+                                    "lat": str(self.latitude),
+                                    "lng": str(self.longitude),
+                                    "gpsheading": str(self.heading),
+                                    "radiobearing": DOA_str,
+                                    "conf": confidence_str,
+                                    "power": max_power_level_str,
+                                    "freq": str(write_freq),
+                                    "anttype": self.DOA_ant_alignment,
+                                    "latency": str(self.latency),
+                                    "processing_time": str(self.processing_time),
+                                    "doaarray": message,
+                                    "adc_overdrive": self.adc_overdrive,
+                                    "num_corr_sources": self.number_of_correlated_sources[0],
+                                    "snr_db": self.snrs[0],
+                                }
+                                try:
+                                    self.pool.apply_async(requests.post, args=[self.RDF_mapper_server, post])
+                                except Exception as e:
+                                    print(f"NO CONNECTION: Invalid Server: {e}")
+                        elif self.DOA_data_format == "Kraken App":
+                            pass  # Just do nothing, stop the invalid doa result error from showing
+                        else:
+                            self.logger.error(f"Invalid DOA Result data format: {self.DOA_data_format}")
+
                 stop_time = time.time()
+
                 que_data_packet.append(["update_rate", stop_time - start_time])
                 que_data_packet.append(
                     [
@@ -682,11 +722,14 @@ class SignalProcessor(threading.Thread):
                 # Too few channels for spatial smoothing, skipping it.
                 pass
 
-        elif self.DOA_decorrelation_method == "FBTOEP":
-            R = fb_toeplitz_reconstruction(R)
-
         M = R.shape[0]
-        scanning_vectors = []
+
+        # If rank of the correlation matrix is not equal to its full one,
+        # then we are likely dealing with correlated sources and (or) low SNR signals
+        number_of_correlated_sources = M - np.linalg.matrix_rank(R)
+        self.number_of_correlated_sources.append(number_of_correlated_sources)
+        self.snrs.append(SNR(R))
+
         frq_ratio = vfo_freq / self.module_receiver.daq_center_freq
         inter_element_spacing = self.DOA_inter_elem_space * frq_ratio
 
@@ -705,6 +748,8 @@ class SignalProcessor(threading.Thread):
             scanning_vectors = gen_scanning_vectors_custom(
                 M, self.custom_array_x * frq_ratio, self.custom_array_y * frq_ratio
             )
+        else:
+            scanning_vectors = np.empty((0, 0))
 
         # DOA estimation
         if self.DOA_algorithm == "Bartlett":  # self.en_DOA_Bartlett:
@@ -740,7 +785,7 @@ class SignalProcessor(threading.Thread):
     # Enable GPS
     def enable_gps(self):
         if self.hasgps:
-            if gpsd.state == {}:
+            if not gpsd.state:
                 gpsd.connect()
                 self.logger.info("Connecting to GPS")
                 self.gps_connected = True
@@ -750,33 +795,40 @@ class SignalProcessor(threading.Thread):
         return self.gps_connected
 
     # Get GPS Data
-    def update_location(self):
+    def update_location_and_timestamp(self):
         if self.gps_connected:
             try:
                 packet = gpsd.get_current()
                 self.latitude, self.longitude = packet.position()
-                if not self.fixed_heading:
-                    self.heading = round(packet.movement().get("track"), 1)
+                if (not self.fixed_heading) and (packet.speed() > self.gps_min_speed_for_valid_heading):
+                    if (time.time() - self.time_of_last_invalid_heading) >= self.gps_min_duration_for_valid_heading:
+                        self.heading = round(packet.movement().get("track"), 1)
+                else:
+                    self.time_of_last_invalid_heading = time.time()
                 self.gps_status = "Connected"
-            except (gpsd.NoFixError, UserWarning):
+                self.gps_timestamp = int(round(1000.0 * packet.get_time().timestamp()))
+            except (gpsd.NoFixError, UserWarning, ValueError, BrokenPipeError):
                 self.latitude = self.longitude = 0.0
-                self.heading if self.fixed_heading else 0.0
+                self.gps_timestamp = 0
+                self.heading = self.heading if self.fixed_heading else 0.0
                 self.logger.error("gpsd error, nofix")
                 self.gps_status = "Error"
         else:
             self.logger.error("Trying to use GPS, but can't connect to gpsd")
             self.gps_status = "Error"
 
-    def wr_xml(self, station_id, doa, conf, pwr, freq, latitude, longitude, heading):
+    def wr_xml(
+        self, station_id, doa, conf, pwr, freq, latitude, longitude, heading, adc_overdrive, num_corr_sources, snr_db
+    ):
         # Kerberos-ify the data
         confidence_str = "{}".format(np.max(int(float(conf) * 100)))
         max_power_level_str = "{:.1f}".format((np.maximum(-100, float(pwr) + 100)))
 
-        epoch_time = int(1000 * round(time.time(), 3))
         # create the file structure
         data = ET.Element("DATA")
         xml_st_id = ET.SubElement(data, "STATION_ID")
         xml_time = ET.SubElement(data, "TIME")
+        xml_gps_time = ET.SubElement(data, "GPS_TIME")
         xml_freq = ET.SubElement(data, "FREQUENCY")
         xml_location = ET.SubElement(data, "LOCATION")
         xml_latitide = ET.SubElement(xml_location, "LATITUDE")
@@ -785,9 +837,15 @@ class SignalProcessor(threading.Thread):
         xml_doa = ET.SubElement(data, "DOA")
         xml_pwr = ET.SubElement(data, "PWR")
         xml_conf = ET.SubElement(data, "CONF")
+        xml_latency = ET.SubElement(data, "LATENCY")
+        xml_processing_time = ET.SubElement(data, "PROCESSING_TIME")
+        xml_adc_overdrive = ET.SubElement(data, "ADC_OVERDRIVE")
+        xml_num_corr_sources = ET.SubElement(data, "NUM_CORRELATED_SOURCES")
+        xml_snr = ET.SubElement(data, "SNR_DB")
 
         xml_st_id.text = str(station_id)
-        xml_time.text = str(epoch_time)
+        xml_time.text = str(self.timestamp)
+        xml_gps_time.text = str(self.gps_timestamp)
         xml_freq.text = str(freq / 1000000)
         xml_latitide.text = str(latitude)
         xml_longitude.text = str(longitude)
@@ -795,6 +853,11 @@ class SignalProcessor(threading.Thread):
         xml_doa.text = doa
         xml_pwr.text = max_power_level_str
         xml_conf.text = confidence_str
+        xml_latency.text = f"{self.latency}"
+        xml_processing_time.text = f"{self.processing_time}"
+        xml_adc_overdrive.text = str(adc_overdrive)
+        xml_num_corr_sources.text = str(num_corr_sources)
+        xml_snr.text = str(snr_db)
 
         # create a new XML file with the results
         html_str = ET.tostring(data, encoding="unicode")
@@ -817,10 +880,8 @@ class SignalProcessor(threading.Thread):
         app_type,
     ):
         if app_type == "Kraken":
-            epoch_time = int(time.time() * 1000)
-
             # KrakenSDR Android App Output
-            message = f"{epoch_time}, {DOA_str}, {confidence_str}, {max_power_level_str}, "
+            message = f"{self.timestamp}, {DOA_str}, {confidence_str}, {max_power_level_str}, "
             message += f"{freq}, {self.DOA_ant_alignment}, {self.latency}, {station_id}, "
             message += f"{latitude}, {longitude}, {heading}, {heading}, "
             message += "GPS, R, R, R, R"  # Reserve 6 entries for other things # NOTE: Second heading is reserved for GPS heading / compass heading differentiation
@@ -837,7 +898,7 @@ class SignalProcessor(threading.Thread):
             confidence_str = "{}".format(np.max(int(float(confidence_str) * 100)))
             max_power_level_str = "{:.1f}".format((np.maximum(-100, float(max_power_level_str) + 100)))
 
-            message = str(int(time.time() * 1000)) + ", " + DOA_str + ", " + confidence_str + ", " + max_power_level_str
+            message = str(self.timestamp) + ", " + DOA_str + ", " + confidence_str + ", " + max_power_level_str
             html_str = (
                 "<DATA>\n<DOA>"
                 + DOA_str
@@ -863,6 +924,9 @@ class SignalProcessor(threading.Thread):
         latitude,
         longitude,
         heading,
+        adc_overdrive,
+        num_corr_sources,
+        snr_db,
     ):
         # KrakenSDR Flutter app out
         doaString = str("")
@@ -877,7 +941,9 @@ class SignalProcessor(threading.Thread):
         #    doaString += ", " + "{:.2f}".format(doa_result_log[i])
 
         jsonDict = {}
-        jsonDict["tStamp"] = int(time.time() * 1000)
+        jsonDict["station_id"] = station_id
+        jsonDict["tStamp"] = self.timestamp
+        jsonDict["gps_timestamp"] = self.gps_timestamp
         jsonDict["latitude"] = str(latitude)
         jsonDict["longitude"] = str(longitude)
         jsonDict["gpsBearing"] = str(heading)
@@ -886,8 +952,12 @@ class SignalProcessor(threading.Thread):
         jsonDict["power"] = max_power_level_str
         jsonDict["freq"] = freq  # self.module_receiver.daq_center_freq
         jsonDict["antType"] = self.DOA_ant_alignment
-        jsonDict["latency"] = 100
+        jsonDict["latency"] = self.latency
+        jsonDict["processing_time"] = self.processing_time
         jsonDict["doaArray"] = doaString
+        jsonDict["adc_overdrive"] = adc_overdrive
+        jsonDict["num_corr_sources"] = num_corr_sources
+        jsonDict["snr_db"] = snr_db
 
         try:
             self.pool.apply_async(
@@ -1100,6 +1170,19 @@ def DOA_MUSIC(R, scanning_vectors, signal_dimension, angle_resolution=1):
     return ADORT
 
 
+# Rather naive way to estimate SNR (in dBs) based on the assumption that largest and smallest eigenvalues
+# of the correlation matrix corresponds to the powers of the signal plus noise  and noise respectively.
+# Even though it won't estimate SNR beyond dominant signal, if it is already quite small,
+# then any additional signals have even lower SNR.
+def SNR(R: np.ndarray) -> float:
+    ev = np.abs(scipy.linalg.eigvals(R))
+    ev.sort()
+    noise_power = ev[0]
+    signal_plus_noise_power = ev[-1]
+    snr = 10.0 * np.log10((signal_plus_noise_power - noise_power) / noise_power)
+    return snr
+
+
 def xi(uca_radius_m: float, frequency_Hz: float) -> Tuple[float, int]:
     wavelength_m = scipy.constants.speed_of_light / frequency_Hz
     x = 2.0 * np.pi * uca_radius_m / wavelength_m
@@ -1146,7 +1229,7 @@ def transform_to_phase_mode_space(signal: np.ndarray, uca_radius_m: float, frequ
 
 # Numba optimized version of pyArgus corr_matrix_estimate with "fast". About 2x faster on Pi4
 # @njit(fastmath=True, cache=True)
-def corr_matrix(X):
+def corr_matrix(X: np.ndarray) -> np.ndarray:
     N = X[0, :].size
     R = np.dot(X, X.conj().T)
     R = np.divide(R, N)


### PR DESCRIPTION
**THIS SHOULD BE MERGED AFTER** #65

- Log GPS timestamps, as it might be beneficial for data synchronization purposes among networked devices.
- Log timestamps in UTC.
- Acquire position, heading and GPS timestamp as close to measurement as possible.
- Refactor data writers (a) to be called after all processing is done and (b) to use common timestamp.
- Report actual latency to the clients.
- When acquiring GPS heading, make sure it is moving faster than the user-defined threshold (2 m/s by default) for a user-defined minimum amount of time (3 s by default).
- Serve last succesful DoA estimate when squelch is used.
- Report additional signal metrics:
  There might be certain conditions where DoA estimation might not be trustworthy. Those include ADC overdrive (due to strong signal or excesive gain), correlated signals (e.g., due to multipath) and low SNR of a signal-of-interest. So lets communicate them with clients, so that they can make informed decision on appropriate DoA data filtering.
