### PR TITLE
Remove setting channel to central frequency

### DIFF
--- a/_UI/_web_interface/kraken_web_interface.py
+++ b/_UI/_web_interface/kraken_web_interface.py
@@ -851,8 +851,12 @@ def update_daq_params(input_value, f0, gain):
         webInterface_inst.config_daq_rf(f0, gain)
 
         for i in range(webInterface_inst.module_signal_processor.max_vfos):
-            webInterface_inst.module_signal_processor.vfo_freq[i] = f0
-            app.push_mods({f"vfo_{i}_freq": {"value": f0}})
+            half_band_width = (webInterface_inst.module_signal_processor.vfo_bw[i] / 10**6) / 2
+            min_freq = webInterface_inst.daq_center_freq - webInterface_inst.daq_fs / 2 + half_band_width
+            max_freq = webInterface_inst.daq_center_freq + webInterface_inst.daq_fs / 2 - half_band_width
+            if not (min_freq < (webInterface_inst.module_signal_processor.vfo_freq[i] / 10**6) < max_freq):
+                webInterface_inst.module_signal_processor.vfo_freq[i] = f0
+                app.push_mods({f"vfo_{i}_freq": {"value": f0}})
 
         wavelength = 300 / webInterface_inst.daq_center_freq
         # webInterface_inst.module_signal_processor.DOA_inter_elem_space = webInterface_inst.ant_spacing_meters / wavelength


### PR DESCRIPTION
## Motivation
Consider user which carefully sets all channels with some parameters and then decided to update gain of receivers ...
Oops, all channels are reset to default value of central frequency ... With big amount of channels it is hard to reconfigure it each time