### PR TITLE
Fix wrong timestamps conversion

### DIFF
--- a/_signal_processing/krakenSDR_signal_processor.py
+++ b/_signal_processing/krakenSDR_signal_processor.py
@@ -252,10 +252,7 @@ class SignalProcessor(threading.Thread):
                 self.is_running = True
                 que_data_packet = []
 
-                utc_timestamp_ms = datetime.utcfromtimestamp(
-                    self.module_receiver.iq_header.time_stamp / 1000.0
-                ).timestamp()
-                self.timestamp = int(round(1000.0 * utc_timestamp_ms))
+                self.timestamp = self.module_receiver.iq_header.time_stamp
 
                 if self.hasgps and self.usegps:
                     self.update_location_and_timestamp()


### PR DESCRIPTION
Unless I am missing something, its seems like using `utcfromtimestamp(...)` with UNIX epoch input and then getting it back as `.timestamp()` incorrectly takes time zone into account leading to inconsistent result. Furthermore, calling `datetime.datetime.utcnow().timestamp()` produces wrong epoch. There are indeed a few warnings in `datetime` documentation discouraging explicit usage of `utc...` methods. Many thanks to @DrunkP for reporting and @dubrsl for clarifying this to me.