### PR TITLE
Add root-MUSIC DoA estimation method

### DIFF
--- a/_UI/_web_interface/kraken_web_config.py
+++ b/_UI/_web_interface/kraken_web_config.py
@@ -7,6 +7,7 @@ import ini_checker
 import tooltips
 from variables import (
     DECORRELATION_OPTIONS,
+    DOA_METHODS,
     calibration_tack_modes,
     daq_config_filename,
     daq_preconfigs_path,
@@ -936,13 +937,7 @@ def generate_config_page_layout(webInterface_inst):
                     html.Div("DoA Algorithm:", id="label_doa_method", className="field-label"),
                     dcc.Dropdown(
                         id="doa_method",
-                        options=[
-                            {"label": "Bartlett", "value": "Bartlett"},
-                            {"label": "Capon", "value": "Capon"},
-                            {"label": "MEM", "value": "MEM"},
-                            {"label": "TNA", "value": "TNA"},
-                            {"label": "MUSIC", "value": "MUSIC"},
-                        ],
+                        options=DOA_METHODS,
                         value=webInterface_inst.module_signal_processor.DOA_algorithm,
                         style={"display": "inline-block"},
                         className="field-body",
@@ -950,6 +945,7 @@ def generate_config_page_layout(webInterface_inst):
                 ],
                 className="field",
             ),
+            html.Div([html.Div("", id="uca_root_music_warning", className="field", style={"color": "#f39c12"})]),
             html.Div(
                 [
                     html.Div("Decorrelation:", id="label_decorrelation", className="field-label"),

--- a/_UI/_web_interface/kraken_web_interface.py
+++ b/_UI/_web_interface/kraken_web_interface.py
@@ -34,6 +34,7 @@ import numpy as np
 # isort: off
 from variables import (
     DECORRELATION_OPTIONS,
+    DOA_METHODS,
     trace_colors,
     doa_fig,
     root_path,
@@ -1294,6 +1295,37 @@ def toggle_custom_array_fields(toggle_value):
         return [{"display": "block"}, {"display": "block"}, {"display": "none"}]
 
 
+# Fallback to MUSIC if "Custom" arrangement is selected for ROOT-MUSIC
+@app.callback(
+    [Output("doa_method", "value")],
+    [Input("radio_ant_arrangement", "value")],
+)
+def fallback_custom_array_to_music(toggle_value):
+    if toggle_value == "Custom" and webInterface_inst.module_signal_processor.DOA_algorithm == "ROOT-MUSIC":
+        return ["MUSIC"]
+    else:
+        return [webInterface_inst.module_signal_processor.DOA_algorithm]
+
+
+# Disable ROOT-MUSIC if "Custom" arrangement is selected
+@app.callback(
+    [Output("doa_method", "options")],
+    [Input("radio_ant_arrangement", "value")],
+)
+def disable_root_music_for_custom_array(toggle_value):
+    if toggle_value == "Custom":
+        return [
+            [
+                dict(doa_method, disabled=True)
+                if doa_method["value"] == "ROOT-MUSIC"
+                else dict(doa_method, disabled=False)
+                for doa_method in DOA_METHODS
+            ]
+        ]
+    else:
+        return [[dict(doa_method, disabled=False) for doa_method in DOA_METHODS]]
+
+
 @app.callback(
     [
         Output(component_id="body_ant_spacing_wavelength", component_property="children"),
@@ -1302,6 +1334,7 @@ def toggle_custom_array_fields(toggle_value):
         Output(component_id="doa_decorrelation_method", component_property="options"),
         Output(component_id="doa_decorrelation_method", component_property="disabled"),
         Output(component_id="uca_decorrelation_warning", component_property="children"),
+        Output(component_id="uca_root_music_warning", component_property="children"),
         Output(component_id="expected_num_of_sources", component_property="options"),
         Output(component_id="expected_num_of_sources", component_property="disabled"),
     ],
@@ -1406,8 +1439,8 @@ def update_dsp_params(
     webInterface_inst.module_signal_processor.DOA_algorithm = doa_method
 
     is_odd_number_of_channels = webInterface_inst.module_signal_processor.channel_number % 2 != 0
-    is_decorrelation_applicable = ant_arrangement != "Custom" and is_odd_number_of_channels
     # UCA->VULA transformation works best if we have odd number of channels
+    is_decorrelation_applicable = ant_arrangement != "Custom" and is_odd_number_of_channels
     webInterface_inst.module_signal_processor.DOA_decorrelation_method = (
         doa_decorrelation_method if is_decorrelation_applicable else DECORRELATION_OPTIONS[0]["value"]
     )
@@ -1433,6 +1466,13 @@ def update_dsp_params(
     else:
         uca_decorrelation_warning = ""
 
+    if ant_arrangement == "UCA" and doa_method == "ROOT-MUSIC":
+        uca_root_music_warning = "WARNING: Using ROOT-MUSIC method with UCA array is still experimental as it might produce inconsistent results."
+    elif ant_arrangement == "Custom" and doa_method == "ROOT-MUSIC":
+        uca_root_music_warning = "WARNING: ROOT-MUSIC cannot be used with 'Custom' antenna arrangement."
+    else:
+        uca_root_music_warning = ""
+
     webInterface_inst.module_signal_processor.DOA_ant_alignment = ant_arrangement
     webInterface_inst._doa_fig_type = doa_fig_type
     webInterface_inst.module_signal_processor.doa_measure = doa_fig_type
@@ -1455,7 +1495,7 @@ def update_dsp_params(
             }
             for c in range(1, webInterface_inst.module_signal_processor.channel_number)
         ]
-        if doa_method == "MUSIC"
+        if "MUSIC" in doa_method
         else [
             {
                 "label": "N/A",
@@ -1465,7 +1505,7 @@ def update_dsp_params(
         ]
     )
 
-    num_of_sources_state = False if doa_method == "MUSIC" else True
+    num_of_sources_state = False if "MUSIC" in doa_method else True
 
     return [
         str(ant_spacing_wavelength),
@@ -1474,6 +1514,7 @@ def update_dsp_params(
         doa_decorrelation_method_options,
         doa_decorrelation_method_state,
         uca_decorrelation_warning,
+        uca_root_music_warning,
         num_of_sources,
         num_of_sources_state,
     ]

--- a/_UI/_web_interface/variables.py
+++ b/_UI/_web_interface/variables.py
@@ -78,3 +78,12 @@ DECORRELATION_OPTIONS = [
     {"label": "Spatial Smoothing", "value": "FBSS"},
     {"label": "F-B Toeplitz", "value": "FBTOEP"},
 ]
+
+DOA_METHODS = [
+    {"label": "Bartlett", "value": "Bartlett"},
+    {"label": "Capon", "value": "Capon"},
+    {"label": "MEM", "value": "MEM"},
+    {"label": "TNA", "value": "TNA"},
+    {"label": "MUSIC", "value": "MUSIC"},
+    {"label": "ROOT-MUSIC", "value": "ROOT-MUSIC"},
+]

--- a/_signal_processing/krakenSDR_signal_processor.py
+++ b/_signal_processing/krakenSDR_signal_processor.py
@@ -45,7 +45,7 @@ import requests
 
 # Signal processing support
 import scipy
-from numba import njit
+from numba import float32, njit, vectorize
 from pyargus import directionEstimation as de
 from scipy import fft, signal
 from signal_utils import fm_demod, write_wav
@@ -67,6 +67,7 @@ except ModuleNotFoundError:
 MIN_SPEED_FOR_VALID_HEADING = 2.0  # m / s
 MIN_DURATION_FOR_VALID_HEADING = 3.0  # s
 DEFAULT_VFO_FIR_ORDER_FACTOR = int(2)
+DEFAULT_ROOT_MUSIC_STD_DEGREES = 1
 
 
 class SignalProcessor(threading.Thread):
@@ -116,7 +117,7 @@ class SignalProcessor(threading.Thread):
         self.DOA_theta = np.linspace(0, 359, 360)
         self.custom_array_x = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
         self.custom_array_y = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
-        self.array_offset = 0
+        self.array_offset = 0.0
         self.DOA_expected_num_of_sources = 1
         self.DOA_decorrelation_method = "Off"
 
@@ -524,11 +525,9 @@ class SignalProcessor(threading.Thread):
                                     # print("IQ DIFFS: " + str(iq_diffs))
                                     # print("IQ DIFFS ANGLE: " + str(np.rad2deg(np.angle(iq_diffs))))
                                     #
-                                    self.estimate_DOA(vfo_channel, self.vfo_freq[i])
+                                    theta_0 = self.estimate_DOA(vfo_channel, self.vfo_freq[i])
 
                                     doa_result_log = DOA_plot_util(self.DOA)
-
-                                    theta_0 = self.DOA_theta[np.argmax(doa_result_log)]
                                     conf_val = calculate_doa_papr(self.DOA)
 
                                     self.doa_max_list[i] = theta_0
@@ -683,7 +682,7 @@ class SignalProcessor(threading.Thread):
                                 self.DOA_res_fd.truncate()
 
                         # Now create output for apps that only take one VFO
-                        DOA_str = f"{int(self.theta_0_list[0])}"
+                        DOA_str = f"{self.theta_0_list[0]}"
                         confidence_str = f"{np.max(self.confidence_list[0]):.2f}"
                         max_power_level_str = f"{np.maximum(-100, self.max_power_level_list[0]):.1f}"
                         doa_result_log = self.doa_result_log_list[0]
@@ -833,7 +832,9 @@ class SignalProcessor(threading.Thread):
         """
 
         antennas_alignment = self.DOA_ant_alignment
-        if self.DOA_decorrelation_method != "Off" and antennas_alignment == "UCA":
+        if antennas_alignment == "UCA" and (
+            self.DOA_algorithm == "ROOT-MUSIC" or self.DOA_decorrelation_method != "Off"
+        ):
             antennas_alignment = "VULA"
 
         if antennas_alignment == "VULA":
@@ -865,7 +866,8 @@ class SignalProcessor(threading.Thread):
         # then we are likely dealing with correlated sources and (or) low SNR signals
         number_of_correlated_sources = M - np.linalg.matrix_rank(R)
         self.number_of_correlated_sources.append(number_of_correlated_sources)
-        self.snrs.append(SNR(R))
+        snr = SNR(R)
+        self.snrs.append(snr)
 
         frq_ratio = vfo_freq / self.module_receiver.daq_center_freq
         inter_element_spacing = self.DOA_inter_elem_space * frq_ratio
@@ -905,6 +907,16 @@ class SignalProcessor(threading.Thread):
                 R, scanning_vectors, signal_dimension=self.DOA_expected_num_of_sources
             )  # de.DOA_MUSIC(R, scanning_vectors, signal_dimension = 1)
             self.DOA = DOA_MUSIC_res
+        if self.DOA_algorithm == "ROOT-MUSIC":
+            is_vula = True if antennas_alignment == "VULA" else False
+            doas = doa_root_music(
+                R, self.DOA_expected_num_of_sources, is_vula, inter_element_spacing, self.array_offset
+            )
+            self.DOA = normalized_gaussian(self.DOA_theta, doas, DEFAULT_ROOT_MUSIC_STD_DEGREES)
+            # since roots are sorted based on how close they are to the unit circle,
+            # which in turn is proportional to SNR,
+            # then the last element should correspond to the strongest signal
+            theta_0 = doas[-1]
 
         # ULA Array, choose bewteen the full omnidirecitonal 360 data, or forward/backward data only
         if self.DOA_ant_alignment == "ULA":
@@ -918,6 +930,11 @@ class SignalProcessor(threading.Thread):
                 min_val = min(self.DOA)
                 self.DOA[thetas[0:90].astype(int)] = min_val
                 self.DOA[thetas[270:360].astype(int)] = min_val
+
+        if self.DOA_algorithm != "ROOT-MUSIC":
+            theta_0 = self.DOA_theta[np.argmax(self.DOA)]
+
+        return theta_0
 
     # Enable GPS
     def enable_gps(self):
@@ -1295,7 +1312,7 @@ def DOA_MUSIC(R, scanning_vectors, signal_dimension, angle_resolution=1):
     # Generate noise subspace matrix
     noise_dimension = M - signal_dimension
 
-    E = np.zeros((M, noise_dimension), dtype=np.complex64)
+    E = np.empty((M, noise_dimension), dtype=np.complex64)
     for i in range(noise_dimension):
         E[:, i] = vi[:, i]
 
@@ -1310,6 +1327,73 @@ def DOA_MUSIC(R, scanning_vectors, signal_dimension, angle_resolution=1):
     return ADORT
 
 
+# transform angle defined in [-pi, pi) range to [0, 2pi) interval
+@vectorize([float32(float32)])
+def to_zero_to_2pi(angle):
+    if angle < np.float32(0.0):
+        angle *= np.float32(-1.0)
+    elif angle > np.float32(0.0):
+        angle = np.float32(2.0 * np.pi) - angle
+    else:
+        pass
+    return angle
+
+
+# transform angle defined in [-pi/2, pi/2) range to [0, pi) interval
+@vectorize([float32(float32)])
+def to_zero_to_pi(angle):
+    if angle < np.float32(0.0):
+        angle *= np.float32(-1.0)
+    elif angle > np.float32(0.0):
+        angle = np.float32(np.pi) - angle
+    else:
+        pass
+    return angle
+
+
+# Root-MUSIC DoA estimator for ULA and UCA
+# A. Barabell,
+# "Improving the resolution performance of eigenstructure-based direction-finding algorithms."
+# ICASSP'83. IEEE International Conference on Acoustics, Speech, and Signal Processing. Vol. 8. IEEE, 1983.
+# doi: 10.1109/ICASSP.1983.1172124
+@njit(fastmath=True, cache=True)
+def doa_root_music(r, signal_dimension, is_vula, inter_element_spacing, array_angle_offset):
+    M = r.shape[0]
+
+    # correlation matrix is Hermitian, so why not to use faster `eigh` solver
+    _, v_i = lin.eigh(r)
+
+    # Generate noise subspace matrix
+    # eigh provides eigenvalues sorted in ascending order out-of-the-box
+    v_i = v_i.astype(np.complex64)
+    e_noise = v_i[:, :-signal_dimension]
+
+    e_ct = e_noise @ e_noise.conj().T
+
+    p_coeff = np.empty(2 * M - 1, dtype=np.complex64)
+    for i in range(-M + 1, M):
+        p_coeff[i + (M - 1)] = np.trace(e_ct, i)
+
+    all_roots = np.roots(p_coeff)
+
+    candidate_roots_abs = np.abs(all_roots)
+    sorted_idx = candidate_roots_abs.argsort()[(M - 1 - signal_dimension) : (M - 1)]
+
+    valid_roots = all_roots[sorted_idx]
+    args = np.angle(valid_roots)
+
+    if is_vula:
+        doas = to_zero_to_2pi(args)
+        doas_deg = np.rad2deg(doas) + array_angle_offset
+        return doas_deg
+
+    doas = np.arcsin(args / (np.float32(inter_element_spacing * 2.0 * np.pi)))
+    doas = to_zero_to_pi(doas)
+    doas_deg = np.rad2deg(doas) + array_angle_offset
+
+    return doas_deg
+
+
 # Rather naive way to estimate SNR (in dBs) based on the assumption that largest and smallest eigenvalues
 # of the correlation matrix corresponds to the powers of the signal plus noise  and noise respectively.
 # Even though it won't estimate SNR beyond dominant signal, if it is already quite small,
@@ -1319,8 +1403,28 @@ def SNR(R: np.ndarray) -> float:
     ev.sort()
     noise_power = ev[0]
     signal_plus_noise_power = ev[-1]
-    snr = 10.0 * np.log10((signal_plus_noise_power - noise_power) / noise_power)
+    power_ratio = (signal_plus_noise_power - noise_power) / noise_power
+    snr = 10.0 * np.log10(power_ratio)
     return snr
+
+
+# Multimodal 360 degrees prediodic Gaussian function
+@njit(fastmath=True, cache=True)
+def normalized_gaussian(x, x0, sigma):
+    doa_spectrum = np.zeros_like(x)
+    for n in range(x0.size):
+        x0_n = x0[n]
+        x0_mirror = 180.0 + x0_n if x0_n < 180.0 else x0_n - 180.0
+        for i in range(x.size):
+            x_i = x[i]
+            x_wrapped = x_i
+            if x0_mirror > 180.0:
+                x_wrapped = x_i if x_i < x0_mirror else x0_mirror - x_i % x0_mirror
+            else:
+                x_wrapped = x_i if x_i >= x0_mirror else 2.0 * x0_mirror - x_i % x0_mirror
+            doa_spectrum[i] += np.exp(-0.5 * ((x_wrapped - x0_n) / sigma) ** 2)
+    doa_spectrum /= doa_spectrum.max()
+    return doa_spectrum
 
 
 def xi(uca_radius_m: float, frequency_Hz: float) -> Tuple[float, int]:


### PR DESCRIPTION
As suggested by A. Barabell, "Improving the resolution performance of eigenstructure-based direction-finding algorithms." ICASSP'83. IEEE International Conference on Acoustics, Speech, and Signal Processing. Vol. 8. IEEE, 1983.
doi: 10.1109/ICASSP.1983.1172124

Works universally for ULA and UCA. For UCA, the PME transformation is automatically applied to input signal in order to get correlation matrix with Vandermonde structure.

Root-MUSIC might provide better performance for low SNRs conditions and, theoretically, less sensitive to amplitude variations across the channels.