### PR TITLE
Fix VFO frequency reporting in VFO-0 Auto Max mode

### DIFF
--- a/_UI/_web_interface/kraken_web_interface.py
+++ b/_UI/_web_interface/kraken_web_interface.py
@@ -34,6 +34,7 @@ import numpy as np
 # isort: off
 from variables import (
     DECORRELATION_OPTIONS,
+    HZ_TO_MHZ,
     trace_colors,
     doa_fig,
     root_path,
@@ -593,6 +594,12 @@ def fetch_dsp_data():
                 webInterface_inst.max_doas_list = data_entry[1].copy()
             elif data_entry[0] == "DoA Squelch":
                 webInterface_inst.squelch_update = data_entry[1].copy()
+            elif data_entry[0] == "VFO-0 Frequency":
+                app.push_mods(
+                    {
+                        "vfo_0_freq": {"value": data_entry[1] * HZ_TO_MHZ},
+                    }
+                )
             else:
                 webInterface_inst.logger.warning("Unknown data entry: {:s}".format(data_entry[0]))
     except queue.Empty:

--- a/_UI/_web_interface/variables.py
+++ b/_UI/_web_interface/variables.py
@@ -78,3 +78,5 @@ DECORRELATION_OPTIONS = [
     {"label": "Spatial Smoothing", "value": "FBSS"},
     {"label": "F-B Toeplitz", "value": "FBTOEP"},
 ]
+
+HZ_TO_MHZ = 1.0e-6

--- a/_signal_processing/krakenSDR_signal_processor.py
+++ b/_signal_processing/krakenSDR_signal_processor.py
@@ -409,6 +409,7 @@ class SignalProcessor(threading.Thread):
                                 if self.vfo_mode == "Auto":  # Mode 1 is Auto Max Mode
                                     max_index = self.spectrum[1, :].argmax()
                                     freq = self.spectrum[0, max_index]
+                                    self.vfo_freq[i] = freq + self.module_receiver.daq_center_freq
 
                                 decimation_factor = max(
                                     (sampling_freq // self.vfo_bw[i]), 1
@@ -568,6 +569,8 @@ class SignalProcessor(threading.Thread):
                             que_data_packet.append(["DoA Confidence", conf_val])
                             que_data_packet.append(["DoA Squelch", update_list])
                             que_data_packet.append(["DoA Max List", self.doa_max_list])
+                            if self.vfo_mode == "Auto":
+                                que_data_packet.append(["VFO-0 Frequency", self.vfo_freq[0]])
 
                             def adjust_theta(theta):
                                 if self.doa_measure == "Compass":


### PR DESCRIPTION
It turns out that in `VFO-0 Auto Max` mode the VFO frequency reported to clients is not updated, neither it is updated in GUI.

Many thanks to @Zadvornyi for reporting.