### PR TITLE
In middleware set remoteServer from settings

### DIFF
--- a/_UI/_web_interface/kraken_web_interface.py
+++ b/_UI/_web_interface/kraken_web_interface.py
@@ -33,6 +33,7 @@ import numpy as np
 # isort: off
 from variables import (
     DECORRELATION_OPTIONS,
+    DEFAULT_MAPPING_SERVER_ENDPOINT,
     DOA_METHODS,
     trace_colors,
     doa_fig,
@@ -178,6 +179,9 @@ class webInterface:
 
         # Kraken Pro Remote Key
         self.module_signal_processor.krakenpro_key = dsp_settings.get("krakenpro_key", "0ae4ca6b3")
+
+        # Mapping Server URL
+        self.mapping_server_url = dsp_settings.get("mapping_server_url", DEFAULT_MAPPING_SERVER_ENDPOINT)
 
         # VFO Configuration
         self.module_signal_processor.spectrum_fig_type = dsp_settings.get("spectrum_calculation", "Single")
@@ -345,6 +349,7 @@ class webInterface:
         data["longitude"] = self.module_signal_processor.longitude
         data["heading"] = self.module_signal_processor.heading
         data["krakenpro_key"] = self.module_signal_processor.krakenpro_key
+        data["mapping_server_url"] = self.mapping_server_url
         data["rdf_mapper_server"] = self.module_signal_processor.RDF_mapper_server
         data["gps_min_speed"] = self.module_signal_processor.gps_min_speed_for_valid_heading
         data["gps_min_speed_duration"] = self.module_signal_processor.gps_min_duration_for_valid_heading

--- a/_UI/_web_interface/utils.py
+++ b/_UI/_web_interface/utils.py
@@ -8,7 +8,12 @@ import numpy as np
 from kraken_web_doa import plot_doa
 from kraken_web_spectrum import plot_spectrum
 from krakenSDR_signal_processor import DEFAULT_VFO_FIR_ORDER_FACTOR
-from variables import HZ_TO_MHZ, daq_config_filename, doa_fig
+from variables import (
+    DEFAULT_MAPPING_SERVER_ENDPOINT,
+    HZ_TO_MHZ,
+    daq_config_filename,
+    doa_fig,
+)
 
 
 def read_config_file_dict(config_fname=daq_config_filename):
@@ -270,6 +275,7 @@ def settings_change_watcher(webInterface_inst, settings_file_path):
         webInterface_inst.module_signal_processor.longitude = dsp_settings.get("longitude", 0.0)
         webInterface_inst.module_signal_processor.heading = dsp_settings.get("heading", 0.0)
         webInterface_inst.module_signal_processor.krakenpro_key = dsp_settings.get("krakenpro_key", 0.0)
+        webInterface_inst.mapping_server_url = dsp_settings.get("mapping_server_url", DEFAULT_MAPPING_SERVER_ENDPOINT)
         webInterface_inst.module_signal_processor.RDF_mapper_server = dsp_settings.get(
             "rdf_mapper_server", "http://RDF_MAPPER_SERVER.com/save.php"
         )

--- a/_UI/_web_interface/variables.py
+++ b/_UI/_web_interface/variables.py
@@ -102,3 +102,5 @@ DOA_METHODS = [
 ]
 
 HZ_TO_MHZ = 1.0e-6
+
+DEFAULT_MAPPING_SERVER_ENDPOINT = "wss://map.krakenrf.com:2096"

--- a/_nodejs/index.js
+++ b/_nodejs/index.js
@@ -11,9 +11,10 @@ const wsport = 8021
 const doaInterval = 250    // Interval the clients should get new doa data in ms
 
 //const remoteServer = 'testmap.krakenrf.com:2096'
-const remoteServer = 'map.krakenrf.com:2096'
+const remoteServerDefault = 'wss://map.krakenrf.com:2096'
 const settingsJsonPath = '_share/settings.json'
 
+let remoteServer = ''
 let lastDoaUpdate = Date.now()
 let settingsJson = {};
 let settingsChanged = false;
@@ -41,6 +42,7 @@ function loadSettingsJson (){
     settingsChanged = true;
     let rawdata = fs.readFileSync(settingsJsonPath);
     settingsJson = JSON.parse(rawdata)
+    remoteServer = settingsJson.mapping_server_url || remoteServerDefault
   }
   /*
   console.log("Loaded Settings from json")
@@ -69,7 +71,7 @@ function websocketPing (){
 }
 
 function websocketConnect (){
-  wsClient = new ws("wss://"+remoteServer);
+  wsClient = new ws(remoteServer);
 
   wsClient.onopen = () => {
     // start ping interval


### PR DESCRIPTION
It is impractical to have remoteServer hardcoded in the middleware, as it might need to be specialized for prospective clients' needs. So lets add `mapping_server_url` to `settings.json` and make middleware set remoteServer from it (defaults to Kraken Pro Remote endpoint).