### PR TITLE
Fix agc setting handling

### DIFF
--- a/_UI/_web_interface/callbacks/update_daq_params.py
+++ b/_UI/_web_interface/callbacks/update_daq_params.py
@@ -1,9 +1,7 @@
-import copy
-
 import numpy as np
 from dash_devices.dependencies import Input, Output, State
 from maindash import app, web_interface
-from variables import AGC_WARNING_DEFAULT_STYLE, AUTO_GAIN_VALUE
+from utils import get_agc_warning_style_from_gain
 
 
 @app.callback_shared(
@@ -17,11 +15,9 @@ from variables import AGC_WARNING_DEFAULT_STYLE, AUTO_GAIN_VALUE
 def update_daq_params(input_value, f0, gain):
     if web_interface.module_signal_processor.run_processing:
         web_interface.daq_center_freq = f0
-        agc = True if (gain == AUTO_GAIN_VALUE) else False
-        web_interface.config_daq_rf(f0, gain, agc)
+        web_interface.config_daq_rf(f0, gain)
 
-        agc_warning_style = copy.deepcopy(AGC_WARNING_DEFAULT_STYLE)
-        agc_warning_style["display"] = "block" if agc else "none"
+        agc_warning_style = get_agc_warning_style_from_gain(gain)
 
         for i in range(web_interface.module_signal_processor.max_vfos):
             half_band_width = (web_interface.module_signal_processor.vfo_bw[i] / 10**6) / 2

--- a/_UI/_web_interface/kraken_web_interface.py
+++ b/_UI/_web_interface/kraken_web_interface.py
@@ -375,13 +375,14 @@ class WebInterface:
     def close(self):
         pass
 
-    def config_daq_rf(self, f0, gain, agc):
+    def config_daq_rf(self, f0, gain):
         """
         Configures the RF parameters in the DAQ module
         """
         self.daq_cfg_iface_status = 1
         self.module_receiver.set_center_freq(int(f0 * 10**6))
-        if agc:
+
+        if gain == AUTO_GAIN_VALUE:
             self.module_receiver.set_if_agc()
         else:
             self.module_receiver.set_if_gain(gain)

--- a/_UI/_web_interface/utils.py
+++ b/_UI/_web_interface/utils.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import queue
@@ -9,6 +10,8 @@ from kraken_web_doa import plot_doa
 from kraken_web_spectrum import plot_spectrum
 from krakenSDR_signal_processor import DEFAULT_VFO_FIR_ORDER_FACTOR
 from variables import (
+    AGC_WARNING_DISABLED_STYLE,
+    AGC_WARNING_ENABLED_STYLE,
     AUTO_GAIN_VALUE,
     DEFAULT_MAPPING_SERVER_ENDPOINT,
     HZ_TO_MHZ,
@@ -471,3 +474,11 @@ def update_daq_status(app, web_interface):
     # Update local recording file size
     recording_file_size = web_interface.module_signal_processor.get_recording_filesize()
     app.push_mods({"body_file_size": {"children": recording_file_size}})
+
+
+def get_agc_warning_style_from_gain(gain):
+    return (
+        copy.deepcopy(AGC_WARNING_ENABLED_STYLE)
+        if gain == AUTO_GAIN_VALUE
+        else copy.deepcopy(AGC_WARNING_DISABLED_STYLE)
+    )

--- a/_UI/_web_interface/variables.py
+++ b/_UI/_web_interface/variables.py
@@ -108,4 +108,5 @@ DEFAULT_MAPPING_SERVER_ENDPOINT = "wss://map.krakenrf.com:2096"
 AUTO_GAIN_VALUE = -100.0
 
 AGC_WARNING = "WARNING: Automatic gain control might lead to erroneous results because (a) it can overshoot and overdrive ADC and (b) gains are controlled independently on each channel."
-AGC_WARNING_DEFAULT_STYLE = {"color": "#f39c12", "display": "none"}
+AGC_WARNING_DISABLED_STYLE = {"display": "none"}
+AGC_WARNING_ENABLED_STYLE = {"color": "#f39c12", "display": "block"}

--- a/_UI/_web_interface/views/daq_config_card.py
+++ b/_UI/_web_interface/views/daq_config_card.py
@@ -9,9 +9,9 @@ from maindash import web_interface
 
 # isort: on
 
+from utils import get_agc_warning_style_from_gain
 from variables import (
     AGC_WARNING,
-    AGC_WARNING_DEFAULT_STYLE,
     AUTO_GAIN_VALUE,
     calibration_tack_modes,
     daq_config_filename,
@@ -136,7 +136,7 @@ def get_daq_config_card_layout():
                     AGC_WARNING,
                     id="agc_warning",
                     className="field",
-                    style=AGC_WARNING_DEFAULT_STYLE,
+                    style=get_agc_warning_style_from_gain(web_interface.module_receiver.daq_rx_gain),
                 )
             ]
         ),


### PR DESCRIPTION
AGC PR broke settings watcher, because agc paramter was not passed to `config_daq_rf` function. Lets remove it from the function interace and let `config_daq_rf` figure out if AGC is requested based on the `gain` value.