### PR TITLE
Share heimdall_daq_fw and krakensdr_doa logs

### DIFF
--- a/gui_run.sh
+++ b/gui_run.sh
@@ -4,6 +4,9 @@ IPADDR="0.0.0.0"
 IPPORT="8081"
 
 SHARED_FOLDER="_share"
+SHARED_FOLDER_DOA_LOGS="${SHARED_FOLDER}/logs/krakensdr_doa"
+SHARED_FOLDER_DAQ_LOGS="${SHARED_FOLDER}/logs/heimdall_daq_fw"
+
 SETTINGS_PATH="${SHARED_FOLDER}/settings.json"
 
 declare -A STATE_TO_MESSAGE=(["true"]="ENABLED" ["false"]="DISABLED")
@@ -26,16 +29,21 @@ echo
 
 echo "Starting KrakenSDR Direction Finder"
 
-# Use only for debugging
-#sudo python3 _UI/_web_interface/kraken_web_interface.py 2> ui.log &
-
 # Create folder, if it does not exists, that will contain data shared with clients
 mkdir -p "${SHARED_FOLDER}"
+# Create folder, if it does not exists, that will contain logs shared with clients
+mkdir -p "${SHARED_FOLDER_DOA_LOGS}"
+mkdir -p "${SHARED_FOLDER_DAQ_LOGS}"
+
 # In virtual box there needs to be a delay between folder creation and the code
+sync
 sleep 0.1
 
+# Start rsync to sync DAQ logs into shared folder
+./util/sync_daq_logs.sh >/dev/null 2>/dev/null &
+
 echo "Web Interface Running at $IPADDR:8080"
-python3 _UI/_web_interface/app.py 2>ui.log &
+python3 _UI/_web_interface/app.py >"${SHARED_FOLDER_DOA_LOGS}/ui.log" 2>&1 &
 
 # Start webserver to share output and settings with clients
 echo "Data Out Server Running at $IPADDR:$IPPORT"

--- a/util/sync_daq_logs.sh
+++ b/util/sync_daq_logs.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+DAQ_LOGS_PATH=$(find ~ -wholename "*/heimdall_daq_fw/Firmware/_logs" 2>/dev/null)
+SHARED_FOLDER_DAQ_LOGS=$(find ~ -wholename "*/krakensdr_doa/_share/logs/heimdall_daq_fw" 2>/dev/null)
+
+if [ -n "$DAQ_LOGS_PATH" ] && [ -n "$SHARED_FOLDER_DAQ_LOGS" ]; then
+    while true; do
+        cp -afu "${DAQ_LOGS_PATH}"/* "${SHARED_FOLDER_DAQ_LOGS}/"
+        sleep 5
+    done
+fi


### PR DESCRIPTION
Compared to ssh, it is a bit more practical for end users to access logs via http. So lets move them to "_share/logs", including periodically syncing heimdall logs there. If legacy php-based web server is used, then user would need to access particular log via explicit path, e.g., http://localhost:8081/logs/krakensdr_doa/ui.log , while miniserver-based server would present a simplistic gui where logs can easily be navigated to. Fixes #101 