### PR TITLE
Skip DoA processing if `get_iq_online` fails

### DIFF
--- a/_signal_processing/krakenSDR_signal_processor.py
+++ b/_signal_processing/krakenSDR_signal_processor.py
@@ -302,7 +302,9 @@ class SignalProcessor(threading.Thread):
                     self.update_location_and_timestamp()
 
                 # -----> ACQUIRE NEW DATA FRAME <-----
-                self.module_receiver.get_iq_online()
+                if self.module_receiver.get_iq_online():
+                    continue
+
                 self.adc_overdrive = self.module_receiver.iq_header.adc_overdrive_flags
 
                 start_time = time.time()


### PR DESCRIPTION
Since `get_iq_online` might fail we might end up with ZeroDivisionError exception and totally crashed processing. So lets check for errors when getting the frames and skip DoA processing if any.