### PR TITLE
Fix AGC handling on startup

### DIFF
--- a/_UI/_web_interface/kraken_web_interface.py
+++ b/_UI/_web_interface/kraken_web_interface.py
@@ -384,10 +384,7 @@ class WebInterface:
         self.daq_cfg_iface_status = 1
         self.module_receiver.set_center_freq(int(f0 * 10**6))
 
-        if gain == AUTO_GAIN_VALUE:
-            self.module_receiver.set_if_agc()
-        else:
-            self.module_receiver.set_if_gain(gain)
+        self.module_receiver.set_if_gain(gain)
 
         self.logger.info("Updating receiver parameters")
         self.logger.info("Center frequency: {:f} MHz".format(f0))

--- a/_UI/_web_interface/variables.py
+++ b/_UI/_web_interface/variables.py
@@ -18,7 +18,7 @@ settings_found = False
 if os.path.exists(settings_file_path):
     settings_found = True
     with open(settings_file_path, "r") as myfile:
-        dsp_settings = json.loads(myfile.read())
+        dsp_settings = json.load(myfile)
 else:
     dsp_settings = dict()
 

--- a/_receiver/krakenSDR_receiver.py
+++ b/_receiver/krakenSDR_receiver.py
@@ -355,6 +355,11 @@ class ReceiverRTLSDR:
             :param: gain: IF gain value [dB]
             :type:  gain: int
         """
+
+        if gain == AUTO_GAIN_VALUE:
+            self.set_if_agc()
+            return
+
         if self.receiver_connection_status:  # Check connection
             self.daq_rx_gain = gain
             self.daq_agc = False


### PR DESCRIPTION
I overlooked that on app startup the gain is set not via `update_daq_params`, but directly via `set_if_gain` that cannot handle AGC request.