### PR TITLE
Watch for settings changes in headless mode

### DIFF
--- a/_UI/_web_interface/callbacks/main.py
+++ b/_UI/_web_interface/callbacks/main.py
@@ -46,11 +46,9 @@ def func(client, connect):
     if connect and len(app.clients) == 1:
         fetch_dsp_data(app, web_interface, spectrum_fig, waterfall_fig)
         fetch_gps_data(app, web_interface)
-        settings_change_watcher(web_interface, settings_file_path)
     elif not connect and len(app.clients) == 0:
         web_interface.dsp_timer.cancel()
         web_interface.gps_timer.cancel()
-        web_interface.settings_change_timer.cancel()
 
 
 @app.callback_shared(
@@ -894,6 +892,9 @@ def reconfig_daq_chain(input_value, freq, gain):
     web_interface.daq_restart = 1
     #    Restart DAQ Subsystem
 
+    # Stop settings file watcher
+    web_interface.settings_change_timer.cancel()
+
     # Stop signal processing
     web_interface.stop_processing()
     web_interface.logger.debug("Signal processing stopped")
@@ -1003,6 +1004,8 @@ def reconfig_daq_chain(input_value, freq, gain):
     print("M: " + str(web_interface.module_receiver.M))
 
     web_interface.module_signal_processor.start()
+
+    settings_change_watcher(web_interface, settings_file_path)
 
     # Reinit the spectrum fig, because number of traces may have changed if
     # tuner count is different

--- a/_UI/_web_interface/kraken_web_interface.py
+++ b/_UI/_web_interface/kraken_web_interface.py
@@ -21,7 +21,7 @@ from krakenSDR_receiver import ReceiverRTLSDR
 
 # Import built-in modules
 from krakenSDR_signal_processor import SignalProcessor
-from utils import read_config_file_dict
+from utils import read_config_file_dict, settings_change_watcher
 
 
 class WebInterface:
@@ -118,11 +118,6 @@ class WebInterface:
 
         self.module_signal_processor.en_DOA_estimation = dsp_settings.get("en_doa", True)
         self.module_signal_processor.DOA_decorrelation_method = dsp_settings.get("doa_decorrelation_method", "Off")
-        self.module_signal_processor.start()
-
-        #############################################
-        #       UI Status and Config variables      #
-        #############################################
 
         # Output Data format.
         self.module_signal_processor.DOA_data_format = dsp_settings.get("doa_data_format", "Kraken App")
@@ -174,6 +169,12 @@ class WebInterface:
             )
             self.module_signal_processor.vfo_demod[i] = dsp_settings.get("vfo_demod_" + str(i), "Default")
             self.module_signal_processor.vfo_iq[i] = dsp_settings.get("vfo_iq_" + str(i), "Default")
+
+        self.module_signal_processor.start()
+
+        #############################################
+        #       UI Status and Config variables      #
+        #############################################
 
         # DAQ Subsystem status parameters
         self.daq_conn_status = 0
@@ -269,6 +270,8 @@ class WebInterface:
 
         if not settings_found:
             self.save_configuration()
+
+        settings_change_watcher(self, settings_file_path)
 
     def save_configuration(self):
         data = {}


### PR DESCRIPTION
Currently, `settings.json` is only monitored for changes if there is a user session present, e.g., web gui is openned in  a browser. This is impractical for headless operation and requires a hack on a client side to fake a user connection to the web gui.