### PR TITLE
Unconditionally save settings after initialization

### DIFF
--- a/_ui/_web_interface/kraken_web_interface.py
+++ b/_ui/_web_interface/kraken_web_interface.py
@@ -268,8 +268,7 @@ class WebInterface:
             self.vfo_cfg_inputs.append(Input(component_id="vfo_" + str(i) + "_demod", component_property="value"))
             self.vfo_cfg_inputs.append(Input(component_id="vfo_" + str(i) + "_iq", component_property="value"))
 
-        if not settings_found:
-            self.save_configuration()
+        self.save_configuration()
 
         settings_change_watcher(self, settings_file_path)
 


### PR DESCRIPTION
For clients that alter `settings.json` to control the app, it is important to have all the available settings listed in the file. This becomes an issue when migrating to software versions that introduce new settings, yet re-using old `settings.json` file. To mitigate this problem, lets update `settings.json` file right after initialization to make sure it contains all the settings available in the corresponding software version.