### PR TITLE
Update DAQ status even if no data from receiver

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/ambv/black
-    rev: 24.1.1
+    rev: 24.2.0
     hooks:
     -   id: black
         language_version: python3

--- a/_sdr/_receiver/iq_header.py
+++ b/_sdr/_receiver/iq_header.py
@@ -26,6 +26,7 @@ class IQHeader:
     FRAME_TYPE_RAMP = 2
     FRAME_TYPE_CAL = 3
     FRAME_TYPE_TRIGW = 4
+    FRAME_TYPE_EMPTY = 5
 
     SYNC_WORD = 0x2BF7B95A
 
@@ -34,8 +35,8 @@ class IQHeader:
         self.header_size = 1024  # size in bytes
         self.reserved_bytes = 192
 
-        self.sync_word = self.SYNC_WORD  # uint32_t
-        self.frame_type = 0  # uint32_t
+        self.sync_word = 0  # uint32_t
+        self.frame_type = self.FRAME_TYPE_EMPTY  # uint32_t
         self.hardware_id = ""  # char [16]
         self.unit_id = 0  # uint32_t
         self.active_ant_chs = 0  # uint32_t


### PR DESCRIPTION
It turns out that the `get_iq_online()` call is blocking. As a result, status updates, both in GUI and `status.json`, are imposible if no frames being received from heimdall, e.g., due to USB or power failures. So lets "unblock" the call by instead reading with timeout (5s currently) Also refactor status updates to be explicit about potential failures.