### PR TITLE
Hide `Reset Configuration` button in `System Control` panel

### DIFF
--- a/_sdr/_signal_processing/kraken_sdr_signal_processor.py
+++ b/_sdr/_signal_processing/kraken_sdr_signal_processor.py
@@ -750,6 +750,28 @@ class SignalProcessor(threading.Thread):
                     self.processing_time = int(1000 * (time.time() - start_time))
 
                     if self.data_ready and self.theta_0_list:
+                        DOA_str = f"{self.theta_0_list[0]}"
+                        confidence_str = f"{np.max(self.confidence_list[0]):.2f}"
+                        max_power_level_str = f"{np.maximum(-100, self.max_power_level_list[0]):.1f}"
+                        doa_result_log = self.doa_result_log_list[0]
+                        write_freq = self.freq_list[0]
+
+                        # Save XML unconditionally, e.g., used by DF-Aggregator
+                        self.wr_xml(
+                            self.station_id,
+                            DOA_str,
+                            confidence_str,
+                            max_power_level_str,
+                            write_freq,
+                            self.latitude,
+                            self.longitude,
+                            self.heading,
+                            self.speed,
+                            self.adc_overdrive,
+                            self.number_of_correlated_sources[0],
+                            self.snrs[0],
+                        )
+
                         # Do Kraken App first as currently its the only one supporting multi-vfo out
                         if self.DOA_data_format != "Kerberos App":
                             message = ""
@@ -782,29 +804,6 @@ class SignalProcessor(threading.Thread):
                             self.DOA_res_fd.seek(0)
                             self.DOA_res_fd.write(message)
                             self.DOA_res_fd.truncate()
-
-                        # Now create output for apps that only take one VFO
-                        DOA_str = f"{self.theta_0_list[0]}"
-                        confidence_str = f"{np.max(self.confidence_list[0]):.2f}"
-                        max_power_level_str = f"{np.maximum(-100, self.max_power_level_list[0]):.1f}"
-                        doa_result_log = self.doa_result_log_list[0]
-                        write_freq = self.freq_list[0]
-
-                        if self.DOA_data_format == "DF Aggregator":
-                            self.wr_xml(
-                                self.station_id,
-                                DOA_str,
-                                confidence_str,
-                                max_power_level_str,
-                                write_freq,
-                                self.latitude,
-                                self.longitude,
-                                self.heading,
-                                self.speed,
-                                self.adc_overdrive,
-                                self.number_of_correlated_sources[0],
-                                self.snrs[0],
-                            )
                         elif self.DOA_data_format == "Kerberos App":
                             self.wr_kerberos(
                                 DOA_str,

--- a/_ui/_web_interface/views/start_stop_card.py
+++ b/_ui/_web_interface/views/start_stop_card.py
@@ -15,10 +15,6 @@ layout = html.Div(
                     [html.Button("Stop Processing", id="btn-stop_proc", className="btn_stop", n_clicks=0)],
                     className="ctr_toolbar_item",
                 ),
-                html.Div(
-                    [html.Button("Reset Configuration", id="btn-save_cfg", className="btn_save_cfg", n_clicks=0)],
-                    className="ctr_toolbar_item",
-                ),
             ],
             className="ctr_toolbar",
         ),

--- a/_ui/_web_interface/views/system_control_card.py
+++ b/_ui/_web_interface/views/system_control_card.py
@@ -26,6 +26,10 @@ def get_system_control_card_layout():
             html.Div(
                 [
                     html.Div(
+                        [html.Button("Reset Configuration", id="btn-save_cfg", className="btn_save_cfg", n_clicks=0)],
+                        className="ctr_toolbar_item",
+                    ),
+                    html.Div(
                         [html.Button("Restart Software", id="btn-restart_sw", className="btn-restart_sw", n_clicks=0)],
                         className="field",
                     ),


### PR DESCRIPTION
It seems like current users tend to press `Reset Configuration` because they assume it is former `Save Configuration` that used to be place in exactly the same place. This might significantly break the workflow in some mission-critical scenarious. So lets safeguard this function by moving it to the (hidden) `System Control` panel. Also, lets output `doa.xml` irrespective of the output format setting, but retain dummy `DF-Aggregator` option to not confuse current and prospective users.