### PR TITLE
Add input validation on the values updated in the web interface.

### DIFF
--- a/_ui/_web_interface/callbacks/main.py
+++ b/_ui/_web_interface/callbacks/main.py
@@ -16,6 +16,7 @@ from kraken_sdr_signal_processor import SignalProcessor, xi
 from kraken_web_config import write_config_file_dict
 from kraken_web_spectrum import init_spectrum_fig
 from utils import fetch_dsp_data, fetch_gps_data, set_clicked, settings_change_watcher
+from utils import is_int, is_float
 from variables import (
     DECORRELATION_OPTIONS,
     DOA_METHODS,
@@ -63,7 +64,8 @@ def update_data_recording_params(filename, en_data_record, write_interval):
     else:
         web_interface.module_signal_processor.en_data_record = False
 
-    web_interface.module_signal_processor.write_interval = float(write_interval)
+    if is_float(write_interval):
+        web_interface.module_signal_processor.write_interval = float(write_interval)
 
 
 @app.callback_shared(Output("download_recorded_file", "data"), [Input("btn_download_file", "n_clicks")])
@@ -266,7 +268,8 @@ def update_vfo_params(*args):
     web_interface.module_signal_processor.vfo_default_squelch_mode = kwargs_dict["vfo_default_squelch_mode"]
     web_interface.module_signal_processor.vfo_default_demod = kwargs_dict["vfo_default_demod"]
     web_interface.module_signal_processor.vfo_default_iq = kwargs_dict["vfo_default_iq"]
-    web_interface.module_signal_processor.max_demod_timeout = int(kwargs_dict["max_demod_timeout"])
+    if is_int(kwargs_dict["max_demod_timeout"]):
+        web_interface.module_signal_processor.max_demod_timeout = int(kwargs_dict["max_demod_timeout"])
 
     active_vfos = kwargs_dict["active_vfos"]
     # If VFO mode is in the VFO-0 Auto Max mode, we active VFOs to 1 only
@@ -274,7 +277,8 @@ def update_vfo_params(*args):
         active_vfos = 1
         app_updates["active_vfos"] = {"value": 1}
 
-    web_interface.module_signal_processor.dsp_decimation = max(int(kwargs_dict["dsp_decimation"]), 1)
+    if is_int(kwargs_dict["dsp_decimation"]):
+        web_interface.module_signal_processor.dsp_decimation = max(int(kwargs_dict["dsp_decimation"]), 1)
     web_interface.module_signal_processor.active_vfos = active_vfos
     web_interface.module_signal_processor.output_vfo = kwargs_dict["output_vfo"]
 
@@ -290,15 +294,18 @@ def update_vfo_params(*args):
         vfo_max = web_interface.daq_center_freq + bw / 2
 
         for i in range(web_interface.module_signal_processor.max_vfos):
-            web_interface.module_signal_processor.vfo_bw[i] = int(min(kwargs_dict["vfo_" + str(i) + "_bw"], bw * 10**6))
+            if is_int(kwargs_dict["vfo_" + str(i) + "_bw"]):
+                web_interface.module_signal_processor.vfo_bw[i] = int(min(kwargs_dict["vfo_" + str(i) + "_bw"], bw * 10**6))
             web_interface.module_signal_processor.vfo_fir_order_factor[i] = int(
                 kwargs_dict["vfo_" + str(i) + "_fir_order_factor"]
             )
-            web_interface.module_signal_processor.vfo_freq[i] = int(
-                max(min(kwargs_dict["vfo_" + str(i) + "_freq"], vfo_max), vfo_min) * 10**6
-            )
+            if is_float(kwargs_dict["vfo_" + str(i) + "_freq"]):
+                web_interface.module_signal_processor.vfo_freq[i] = int(
+                    max(min(kwargs_dict["vfo_" + str(i) + "_freq"], vfo_max), vfo_min) * 10**6
+                )
             web_interface.module_signal_processor.vfo_squelch_mode[i] = kwargs_dict[f"vfo_squelch_mode_{i}"]
-            web_interface.module_signal_processor.vfo_squelch[i] = int(kwargs_dict["vfo_" + str(i) + "_squelch"])
+            if is_int(kwargs_dict["vfo_" + str(i) + "_squelch"]):
+                web_interface.module_signal_processor.vfo_squelch[i] = int(kwargs_dict["vfo_" + str(i) + "_squelch"])
             web_interface.module_signal_processor.vfo_demod[i] = kwargs_dict[f"vfo_{i}_demod"]
             web_interface.module_signal_processor.vfo_iq[i] = kwargs_dict[f"vfo_{i}_iq"]
 
@@ -501,7 +508,8 @@ def update_dsp_params(
     custom_array_y_meters,
     en_peak_hold,
 ):  # , input_value):
-    web_interface.ant_spacing_meters = spacing_meter
+    if is_float(spacing_meter, minimum=0.0):
+        web_interface.ant_spacing_meters = spacing_meter
     wavelength = 300 / web_interface.daq_center_freq
 
     # web_interface.module_signal_processor.DOA_inter_elem_space = web_interface.ant_spacing_meters / wavelength
@@ -604,10 +612,12 @@ def update_dsp_params(
     web_interface.module_signal_processor.DOA_ant_alignment = ant_arrangement
     web_interface._doa_fig_type = doa_fig_type
     web_interface.module_signal_processor.doa_measure = doa_fig_type
-    web_interface.compass_offset = compass_offset
+    if is_int(compass_offset):
+        web_interface.compass_offset = compass_offset
     web_interface.module_signal_processor.compass_offset = compass_offset
     web_interface.module_signal_processor.ula_direction = ula_direction
-    web_interface.module_signal_processor.array_offset = array_offset
+    if is_int(compass_offset):
+        web_interface.module_signal_processor.array_offset = array_offset
 
     if en_peak_hold is not None and len(en_peak_hold):
         web_interface.module_signal_processor.en_peak_hold = True

--- a/_ui/_web_interface/utils.py
+++ b/_ui/_web_interface/utils.py
@@ -1,5 +1,6 @@
 import copy
 import json
+from math import inf
 import os
 import queue
 from configparser import ConfigParser
@@ -246,6 +247,8 @@ def settings_change_watcher(web_interface, settings_file_path, last_attempt_fail
             try:
                 with open(settings_file_path, "r", encoding="utf-8") as file:
                     dsp_settings = json.load(file)
+                    if dsp_settings == None:
+                        raise RuntimeError('%s appears empty' % file)
             except Exception as ex:
                 if not last_attempt_failed:
                     web_interface.logger.error("Problem loading settings file: %s", ex)
@@ -261,8 +264,6 @@ def settings_change_watcher(web_interface, settings_file_path, last_attempt_fail
                     if dsp_settings.get("uniform_gain", 1.4) != "Auto"
                     else AUTO_GAIN_VALUE
                 )
-
-                web_interface.ant_spacing_meters = float(dsp_settings.get("ant_spacing_meters", 0.5))
 
                 web_interface.en_system_control = [1] if dsp_settings.get("en_system_control", False) else []
                 web_interface.en_beta_features = [1] if dsp_settings.get("en_beta_features", False) else []
@@ -590,3 +591,23 @@ def get_agc_warning_style_from_gain(gain):
         if gain == AUTO_GAIN_VALUE
         else copy.deepcopy(AGC_WARNING_DISABLED_STYLE)
     )
+
+
+'''
+Input validation utilities
+'''
+
+def is_float(string, minimum=-inf, maximum=inf):
+    try:
+        f = float(string)
+        return f >= minimum and f <= maximum
+    except (ValueError, TypeError):
+        return False
+
+def is_int(string, minimum=-inf, maximum=inf):
+    try:
+        i = int(string)
+        return i >= minimum and i <= maximum
+    except (ValueError, TypeError):
+        return False
+


### PR DESCRIPTION
Failure to do this risks crashing the code on the int() or float() casts.  Its also possible for an invalid value to be written which if the user saves the configuration which will prevent the web interface program from starting again so the invalid configuration variable can't be fixed with the GUI.
How to reproduce:
1) Start with a working configuration
2) Erase the contents of the ant_spacing_meters field or just enter a non-number 3) Push save configuration
The only way to recover is to use shell access and fix or replace the krakensdr_doa/_ui/settings.json file.