### PR TITLE
Fix kraken_sdr_signal_processor.py crashing when using RDF Mapper config

### DIFF
--- a/_sdr/_signal_processing/kraken_sdr_signal_processor.py
+++ b/_sdr/_signal_processing/kraken_sdr_signal_processor.py
@@ -850,7 +850,7 @@ class SignalProcessor(threading.Thread):
                             ):  # Upload to RDF Mapper server only every 1s to ensure we dont overload his server
                                 self.rdf_mapper_last_write_time = time.time()
                                 elat, elng = calculate_end_lat_lng(
-                                    self.latitude, self.longitude, int(DOA_str), self.heading
+                                    self.latitude, self.longitude, int(float(DOA_str)), self.heading # DOA_str needs to be converted to stop crashing here
                                 )
                                 rdf_post = {
                                     "id": self.station_id,


### PR DESCRIPTION
When using the RDF Mapper code, this crashed on line 853 due to int(DOA_str) ValueError. Converting to float first seems to keep things happy.