### PR TITLE
Update settings.json when click on spectrum

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,12 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/ambv/black
-    rev: 24.2.0
+    rev: 24.4.2
     hooks:
     -   id: black
         language_version: python3
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+    rev: 7.1.0
     hooks:
     -   id: flake8
         additional_dependencies:

--- a/_sdr/_signal_processing/kraken_sdr_signal_processor.py
+++ b/_sdr/_signal_processing/kraken_sdr_signal_processor.py
@@ -844,10 +844,10 @@ class SignalProcessor(threading.Thread):
                                     self.heading,
                                     self.speed,
                                     self.adc_overdrive,
-                                    self.number_of_correlated_sources[0], # maybe needs j as well
-                                    self.snrs[0], # maybe needs j as well
+                                    self.number_of_correlated_sources[0],  # maybe needs j as well
+                                    self.snrs[0],  # maybe needs j as well
                                 )
-                        
+
                         elif self.DOA_data_format == "RDF Mapper":
                             time_elapsed = time.time() - self.rdf_mapper_last_write_time
                             if (
@@ -855,7 +855,10 @@ class SignalProcessor(threading.Thread):
                             ):  # Upload to RDF Mapper server only every 1s to ensure we dont overload his server
                                 self.rdf_mapper_last_write_time = time.time()
                                 elat, elng = calculate_end_lat_lng(
-                                    self.latitude, self.longitude, int(float(DOA_str)), self.heading # DOA_str needs to be converted to stop crashing here
+                                    self.latitude,
+                                    self.longitude,
+                                    int(float(DOA_str)),
+                                    self.heading,  # DOA_str needs to be converted to stop crashing here
                                 )
                                 rdf_post = {
                                     "id": self.station_id,

--- a/_ui/_web_interface/callbacks/main.py
+++ b/_ui/_web_interface/callbacks/main.py
@@ -419,13 +419,17 @@ def clear_cache_btn(input_value):
 
 
 @app.callback_shared(None, [Input("spectrum-graph", "clickData")])
-def click_to_set_freq_spectrum(clickData):
-    set_clicked(web_interface, clickData)
+def click_to_set_freq_spectrum(click_data):
+    output = set_clicked(web_interface, click_data)
+    web_interface.save_configuration()
+    return output
 
 
 @app.callback_shared(None, [Input("waterfall-graph", "clickData")])
-def click_to_set_waterfall_spectrum(clickData):
-    set_clicked(web_interface, clickData)
+def click_to_set_waterfall_spectrum(click_data):
+    output = set_clicked(web_interface, click_data)
+    web_interface.save_configuration()
+    return output
 
 
 # Enable custom input fields

--- a/_ui/_web_interface/utils.py
+++ b/_ui/_web_interface/utils.py
@@ -8,6 +8,7 @@ from threading import Timer
 
 import numpy as np
 import variables
+from dash_devices.dependencies import Output
 from kraken_sdr_signal_processor import DEFAULT_VFO_FIR_ORDER_FACTOR
 from kraken_web_doa import plot_doa
 from kraken_web_spectrum import plot_spectrum
@@ -75,6 +76,7 @@ def set_clicked(web_interface, clickData):
         web_interface.selected_vfo = vfo_idx
         if web_interface.module_signal_processor.output_vfo >= 0:
             web_interface.module_signal_processor.output_vfo = vfo_idx
+            return Output("output_vfo", "value", vfo_idx)
     else:
         idx = 0
         if web_interface.module_signal_processor.output_vfo >= 0:
@@ -82,6 +84,8 @@ def set_clicked(web_interface, clickData):
         else:
             idx = web_interface.selected_vfo
         web_interface.module_signal_processor.vfo_freq[idx] = int(clickData["points"][0]["x"])
+        return Output(f"vfo_{idx}_freq", "value", web_interface.module_signal_processor.vfo_freq[idx] * HZ_TO_MHZ)
+    return None
 
 
 def fetch_dsp_data(app, web_interface, spectrum_fig, waterfall_fig):


### PR DESCRIPTION
Turns out when VFO frequency is set via clicking on spectrum/waterfall, the settings.json is not updated. Let's fix that at the expenses of potential duplicated `settings.json` updpate if `config` and `spectrum` pages are opened simultaniously.