### PR TITLE
Properly start/stop KrakenToTAK.py

### DIFF
--- a/kill.sh
+++ b/kill.sh
@@ -8,6 +8,11 @@ else
     KILL_SIGNAL=64
 fi
 
+# Kill the Python web interface process
 sudo kill -${KILL_SIGNAL} $(ps ax | grep ".*[p]ython3 .*_ui/_web_interface/app.py" | awk '{print $1}') 2> /dev/null
+# Kill PHP processes
 sudo kill -${KILL_SIGNAL} $(ps ax | grep "[p]hp" | awk '{print $1}') 2> /dev/null
+# Kill Node.js processes
 sudo pkill -f node
+# Kill KrakenToTAK.py if running
+sudo pkill -f "python.*KrakenToTAK.py" 2> /dev/null

--- a/util/kraken_doa_start.sh
+++ b/util/kraken_doa_start.sh
@@ -22,10 +22,18 @@ sleep 1
 cd ../../krakensdr_doa
 sudo env "PATH=$PATH" ./gui_run.sh
 
+# Start the  KrakenToTAK python service if it is installed, and not already running.
 if [ -d "../Kraken-to-TAK-Python" ]; then
     echo "TAK Server Installed"
     cd ../Kraken-to-TAK-Python
-    python KrakenToTAK.py >/dev/null 2>/dev/null &
+
+    # Check if the process is already running
+    if pgrep -f "python KrakenToTAK.py" > /dev/null; then
+        echo "KrakenToTAK.py is already running."
+    else
+        echo "Starting KrakenToTAK.py"
+        python KrakenToTAK.py >/dev/null 2>/dev/null &
+    fi
 else
     echo "TAK Server NOT Installed"
 fi


### PR DESCRIPTION
`kill.sh`  
- Added comments to see what each command was killing
- Added new kill command for KrakenToTAK.py so the service is shut down and does not build up stale processes each time Kraken is stopped/started. 


`kraken_doa_start.sh`
- Check if KrakenToTAK.py is already running instead of blindly starting it each time
-  Improved logging to show if TAK Plugin is installed and if the service was already running or started fresh.