### PR TITLE
Support new numpy and scipy versions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
       - uses: py-actions/flake8@v2
         with:
           plugins: "flake8-bugbear flake8-black Flake8-pyproject"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
 -   repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
     -   id: isort
 -   repo: https://github.com/ambv/black
-    rev: 24.4.2
+    rev: 25.1.0
     hooks:
     -   id: black
         language_version: python3
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.1.0
+    rev: 7.1.2
     hooks:
     -   id: flake8
         additional_dependencies:

--- a/_sdr/_receiver/shmemIface.py
+++ b/_sdr/_receiver/shmemIface.py
@@ -1,22 +1,22 @@
 """
-    HeIMDALL DAQ Firmware
-    Python based shared memory interface implementations
+ HeIMDALL DAQ Firmware
+ Python based shared memory interface implementations
 
-    Author: Tamás Pető
-    License: GNU GPL V3
+ Author: Tamás Pető
+ License: GNU GPL V3
 
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   any later version.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+any later version.
 
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import logging

--- a/_sdr/_signal_processing/signal_utils.py
+++ b/_sdr/_signal_processing/signal_utils.py
@@ -1,8 +1,14 @@
 import math
+import operator
 import shutil
 
 import numpy as np
-from scipy.signal import butter, firwin, lfilter
+from scipy.signal import (
+    butter,
+    firwin,
+    lfilter,
+    resample_poly,
+)
 
 DEFAULT_NUM_OF_FREQ = 1024
 DEFAULT_FILTER_ORDER = 5
@@ -10,6 +16,33 @@ DEFAULT_FILTER_WINDOW = "hamming"
 DEFAULT_NUM_TAPS = 256
 
 DISK_SPACE_HEADROOM = 0.1
+
+
+def decimate_custom_fir(x, q, b, a):
+    """
+    Downsample the signal after applying given FIR filter.
+
+    Parameters
+    ----------
+    x : array_like
+        The signal to be downsampled, as an N-dimensional array.
+    q : int
+        The downsampling factor.
+    b: array_like
+        Numerator of the transfer function.
+    a: array_like
+        Denominator of the transfer function.
+    """
+
+    x = np.asarray(x)
+    q = operator.index(q)
+
+    sl = [slice(None)] * x.ndim
+
+    b = b / a
+    y = resample_poly(x, 1, q, axis=-1, window=b)
+
+    return y[tuple(sl)]
 
 
 def audible(signal):

--- a/_ui/_web_interface/callbacks/main.py
+++ b/_ui/_web_interface/callbacks/main.py
@@ -538,7 +538,7 @@ def update_dsp_params(
         )
         web_interface.module_signal_processor.DOA_inter_elem_space = inter_elem_spacing / wavelength
     else:
-        web_interface.module_signal_processor.DOA_UCA_radius_m = np.Infinity
+        web_interface.module_signal_processor.DOA_UCA_radius_m = np.inf
         web_interface.module_signal_processor.DOA_inter_elem_space = web_interface.ant_spacing_meters / wavelength
 
     ant_spacing_wavelength = round(web_interface.module_signal_processor.DOA_inter_elem_space, 3)
@@ -547,8 +547,8 @@ def update_dsp_params(
 
     # Split CSV input in custom array
 
-    web_interface.custom_array_x_meters = np.float_(custom_array_x_meters.split(","))
-    web_interface.custom_array_y_meters = np.float_(custom_array_y_meters.split(","))
+    web_interface.custom_array_x_meters = np.float64(custom_array_x_meters.split(","))
+    web_interface.custom_array_y_meters = np.float64(custom_array_y_meters.split(","))
 
     web_interface.module_signal_processor.custom_array_x = web_interface.custom_array_x_meters / wavelength
     web_interface.module_signal_processor.custom_array_y = web_interface.custom_array_y_meters / wavelength

--- a/_ui/_web_interface/kraken_web_interface.py
+++ b/_ui/_web_interface/kraken_web_interface.py
@@ -93,7 +93,7 @@ class WebInterface:
                 300 / float(dsp_settings.get("center_freq", 100.0))
             )
         else:
-            self.module_signal_processor.DOA_UCA_radius_m = np.Infinity
+            self.module_signal_processor.DOA_UCA_radius_m = np.inf
             self.module_signal_processor.DOA_inter_elem_space = self.ant_spacing_meters / (
                 300 / float(dsp_settings.get("center_freq", 100.0))
             )
@@ -102,10 +102,10 @@ class WebInterface:
         self.module_signal_processor.DOA_algorithm = dsp_settings.get("doa_method", "MUSIC")
         self.module_signal_processor.DOA_expected_num_of_sources = dsp_settings.get("expected_num_of_sources", 1)
 
-        self.custom_array_x_meters = np.float_(
+        self.custom_array_x_meters = np.float64(
             dsp_settings.get("custom_array_x_meters", "0.21,0.06,-0.17,-0.17,0.07").split(",")
         )
-        self.custom_array_y_meters = np.float_(
+        self.custom_array_y_meters = np.float64(
             dsp_settings.get("custom_array_y_meters", "0.00,-0.20,-0.12,0.12,0.20").split(",")
         )
         self.module_signal_processor.custom_array_x = self.custom_array_x_meters / (

--- a/_ui/_web_interface/utils.py
+++ b/_ui/_web_interface/utils.py
@@ -291,15 +291,15 @@ def settings_change_watcher(web_interface, settings_file_path, last_attempt_fail
                     )
                     web_interface.module_signal_processor.DOA_inter_elem_space = inter_elem_spacing / wavelength
                 else:
-                    web_interface.module_signal_processor.DOA_UCA_radius_m = np.Infinity
+                    web_interface.module_signal_processor.DOA_UCA_radius_m = np.inf
                     web_interface.module_signal_processor.DOA_inter_elem_space = (
                         web_interface.ant_spacing_meters / wavelength
                     )
 
-                web_interface.custom_array_x_meters = np.float_(
+                web_interface.custom_array_x_meters = np.float64(
                     dsp_settings.get("custom_array_x_meters", "0.1,0.2,0.3,0.4,0.5").split(",")
                 )
-                web_interface.custom_array_y_meters = np.float_(
+                web_interface.custom_array_y_meters = np.float64(
                     dsp_settings.get("custom_array_y_meters", "0.1,0.2,0.3,0.4,0.5").split(",")
                 )
                 web_interface.module_signal_processor.custom_array_x = web_interface.custom_array_x_meters / (


### PR DESCRIPTION
- replace scipy `decimate` with custom implementation that does not need to check if system is fir filter and incur major runtime penalty from calling `ftype._as_zpk()`;
- fix deprecated numpy types.