### PR TITLE
Enable Web Socket Capability as a Headless Application

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+KrakenSDR DoA DSP is a real-time direction of arrival (DoA) estimation system for the KrakenSDR and compatible RTL-SDR coherent receiver arrays. It processes IQ data from the Heimdall DAQ firmware to determine the bearing of RF signals.
+
+## Development Commands
+
+### Environment Setup
+```bash
+conda activate kraken  # Required before any Python work
+```
+
+### Running the Application
+```bash
+./util/kraken_doa_start.sh   # Full startup: DAQ + DSP (local hardware)
+./gui_run.sh                  # DSP/UI only (DAQ runs remotely)
+./kill.sh                     # Stop all services
+```
+
+### Code Quality (pre-commit hooks)
+```bash
+pre-commit install            # Set up hooks once
+pre-commit run --all-files    # Run manually
+```
+
+Formatting tools and their config (in `pyproject.toml`):
+- **Black**: line length 120
+- **isort**: profile `black`
+- **Flake8**: line length 120, ignores `DUO107,E402,E501,E203,W503`
+
+CI runs isort+Black (formatting) and Flake8 (linting) on all push/PR.
+
+## Architecture
+
+### Three Main Subsystems
+
+**1. Signal Processing (`_sdr/`)**
+- `_receiver/kraken_sdr_receiver.py` — Acquires IQ data from Heimdall DAQ via Ethernet (`eth` mode, port 5000) or shared memory (`shmem` mode). Configures frequency, gain, AGC.
+- `_signal_processing/kraken_sdr_signal_processor.py` — Core `threading.Thread` running DoA estimation (Bartlett, Capon, MEM, TNA, MUSIC, ROOT-MUSIC via **pyargus**). Uses **Numba JIT** for performance-critical paths — first run is slow due to compilation.
+- `_signal_processing/signal_utils.py` — FM demodulation, FIR/Butterworth filters, IQ file I/O.
+
+**2. Web UI (`_ui/_web_interface/`)**
+- `app.py` — Entry point. Starts Quart/Dash server (port 8080), WebSocket server (port 8082), and periodic data pump timers.
+- `kraken_web_interface.py` — Main coordinator: manages queues between receiver, signal processor, and UI; monitors `_share/settings.json` via timestamp polling.
+- `callbacks/main.py` — All Dash callback logic (~51K, core of UI interactivity).
+- `utils.py` — `fetch_dsp_data()` and `fetch_gps_data()` poll signal processor and push to Dash via `app.push_mods()`.
+- `kraken_ws_server.py` — Custom RFC 6455 WebSocket server (asyncio/TCP, no external deps). Broadcasts DoA/spectrum JSON to `ws://<host>:8082/ws/kraken`.
+- `views/` — Individual UI card components (DAQ config, DSP config, VFO, station config, etc.).
+
+**3. Node.js Middleware (`_nodejs/`)**
+- `index.js` — Express REST API (port 8042) + WebSocket client (port 8021). Proxies data to `wss://map.krakenrf.com:2096`, provides settings load/save API.
+
+### Data Flow
+```
+Heimdall DAQ → ReceiverRTLSDR → SignalProcessor (Thread)
+    → WebInterface (queues) → Dash UI (port 8080)
+                            → WebSocket broadcast (port 8082)
+    ← settings.json ← Node.js API (port 8042) ← Remote clients
+                    ← miniserve/PHP (port 8081)
+```
+
+### Key Shared State
+- `_share/settings.json` — Runtime configuration; watched by timestamp polling, written by UI callbacks and Node.js API.
+- `_share/status.json` — Current system status pushed from signal processor.
+- `_share/logs/` — Per-module log files.
+- `_data_control/` — Shared memory control flags for DAQ↔DSP synchronization.
+
+### Port Map
+| Port | Service |
+|------|---------|
+| 5000 | Heimdall DAQ (Ethernet IQ stream) |
+| 8080 | Web UI (Dash/Quart) |
+| 8081 | File server (miniserve or PHP) |
+| 8082 | WebSocket server (custom asyncio) |
+| 8042 | Node.js REST API |
+| 8021 | Node.js WebSocket endpoint |
+
+## Important Development Notes
+
+- **Numba JIT**: `kraken_sdr_signal_processor.py` uses `@numba.jit` decorators. Expect 1-2 min startup on first run; compiled cache speeds up subsequent runs.
+- **Settings watching**: `_share/settings.json` changes are detected via `os.path.getmtime()` polling in `utils.py`, not inotify — changes apply on the next poll cycle.
+- **Remote vs local DAQ**: Switch between `eth` and `shmem` receiver modes in settings. Shared memory mode requires Heimdall DAQ on the same machine.
+- **Heimdall DAQ dependency**: The `../heimdall_daq_fw/` sibling directory is expected to exist for full local operation. DAQ `daq_chain_config.ini` is loaded from that path.
+- **Conda environment**: The `kraken` conda environment must be active; the app is not designed for system Python.

--- a/README.md
+++ b/README.md
@@ -152,28 +152,130 @@ After starting the script a web based server opens at port number `8080`, which 
 ![image](https://user-images.githubusercontent.com/78108016/175924475-2ce0a189-e119-4442-8893-0d32404847e2.png)
 
 
-### Remote control
+### Headless Mode
 
-The `settings.json` file that contains most of the DoA DSP settings is served via HTTP and can be accessed via `http://KRAKEN_IP:8081/settings.json`. Not only the client can download it on the remote machine, but also upload `settings.json` to the host that runs DSP software via, e.g.,
+The application can run entirely without the web GUI. In headless mode the Dash server (port 8080) and file server (port 8081) are not started — the WebSocket on port 8082 is the sole interface for both receiving data and sending commands.
 
 ```bash
+./gui_run.sh --headless
+```
+
+Data streams and commands work identically to GUI mode. The GUI can still be opened later by restarting without `--headless`.
+
+### WebSocket Interface
+
+All data output and remote control is available via a single WebSocket endpoint:
+
+```
+ws://KRAKEN_IP:8082/ws/kraken
+```
+
+No authentication is required. On connect, the server immediately pushes the current settings snapshot.
+
+#### Outbound messages (server → client)
+
+Every message is a JSON object with a `type` field and a `timestamp` (epoch milliseconds):
+
+```
+{ "type": "settings", "timestamp": 1714000000000, "center_freq": 416.588, ... }
+{ "type": "doa",      "timestamp": 1714000000000, "doa_max": 135.0, ... }
+{ "type": "spectrum", "timestamp": 1714000000000, "freq_axis": [...], "channels": { "ch0": [...] } }
+```
+
+#### Inbound commands (client → server)
+
+Send a JSON object to update any combination of settings. Only the keys you include are changed — the rest are preserved.
+
+```json
+{
+  "type": "command",
+  "action": "update_settings",
+  "data": {
+    "center_freq": 433.92,
+    "uniform_gain": 20.0
+  }
+}
+```
+
+Changes apply immediately to the signal processor. If the GUI is open, all form fields update automatically within one second.
+
+#### Settings reference
+
+| Key | Type | Valid values / range | Default |
+|-----|------|----------------------|---------|
+| `center_freq` | float (MHz) | ≥ 24.0 | `416.588` |
+| `uniform_gain` | float (dB) or string | `0, 0.9, 1.4, 2.7, 3.7, 7.7, 8.7, 12.5, 14.4, 15.7, 16.6, 19.7, 20.7, 22.9, 25.4, 28.0, 29.7, 32.8, 33.8, 36.4, 37.2, 38.6, 40.2, 42.1, 43.4, 43.9, 44.5, 48.0, 49.6` or `"Auto"` | `15.7` |
+| `data_interface` | string | `"shmem"`, `"eth"` | `"shmem"` |
+| `default_ip` | string | Any IP address | `"0.0.0.0"` |
+| **DoA** | | | |
+| `en_doa` | bool | `true`, `false` | `true` |
+| `ant_arrangement` | string | `"UCA"`, `"ULA"`, `"Custom"` | `"UCA"` |
+| `ula_direction` | string | `"Both"`, `"Forward"`, `"Backward"` | `"Both"` |
+| `ant_spacing_meters` | float (m) | ≥ 0.001 | `0.21` |
+| `custom_array_x_meters` | string | Comma-separated floats, one per channel | `"0.21,0.06,-0.17,-0.17,0.07"` |
+| `custom_array_y_meters` | string | Comma-separated floats, one per channel | `"0.00,-0.20,-0.12,0.12,0.20"` |
+| `array_offset` | int (degrees) | Any integer | `0` |
+| `doa_method` | string | `"Bartlett"`, `"Capon"`, `"MEM"`, `"TNA"`, `"MUSIC"`, `"ROOT-MUSIC"` | `"MUSIC"` |
+| `doa_decorrelation_method` | string | `"Off"`, `"FBA"`, `"TOEP"`, `"FBSS"`, `"FBTOEP"` | `"Off"` |
+| `expected_num_of_sources` | int | `1`, `2`, `3`, `4` | `1` |
+| `compass_offset` | int (degrees) | Any integer | `0` |
+| `doa_fig_type` | string | `"Linear"`, `"Polar"`, `"Compass"` | `"Linear"` |
+| `en_peak_hold` | bool | `true`, `false` | `false` |
+| **Station** | | | |
+| `station_id` | string | Any string | `"NOCALL"` |
+| `location_source` | string | `"None"`, `"Static"`, `"gpsd"` | `"None"` |
+| `latitude` | float | -90.0 to 90.0 | `0.0` |
+| `longitude` | float | -180.0 to 180.0 | `0.0` |
+| `heading` | float (degrees) | 0.0 to 360.0 | `0.0` |
+| `gps_fixed_heading` | bool | `true`, `false` | `false` |
+| `gps_min_speed` | float (m/s) | > 0 | `2` |
+| `gps_min_speed_duration` | int (s) | > 0 | `3` |
+| `doa_data_format` | string | `"Kraken App"`, `"Kraken Pro Local"`, `"Kraken Pro Remote"`, `"Kerberos App"`, `"DF Aggregator"`, `"RDF Mapper"`, `"Full POST"` | `"Kraken App"` |
+| `krakenpro_key` | string | Any string | — |
+| `mapping_server_url` | string | WebSocket URL | `"wss://map.krakenrf.com:2096"` |
+| `rdf_mapper_server` | string | HTTP URL | — |
+| **VFO** | | | |
+| `spectrum_calculation` | string | `"Single"`, `"All"` | `"Single"` |
+| `vfo_mode` | string | `"Standard"`, `"Auto"` | `"Standard"` |
+| `active_vfos` | int | 1 – 16 | `1` |
+| `output_vfo` | int | -1 (all), 0 – 15 | `0` |
+| `dsp_decimation` | int | ≥ 1 | `1` |
+| `vfo_default_squelch_mode` | string | `"Auto"`, `"Manual"`, `"Auto Channel"` | `"Auto"` |
+| `vfo_default_demod` | string | `"None"`, `"FM"` | `"None"` |
+| `vfo_default_iq` | string | `"False"`, `"True"` | `"False"` |
+| `max_demod_timeout` | int (s) | > 0 | `60` |
+| `en_optimize_short_bursts` | bool | `true`, `false` | `false` |
+| **Per-VFO** (replace `N` with 0–15) | | | |
+| `vfo_freq_N` | float (Hz) | Within tuned bandwidth | center freq |
+| `vfo_bw_N` | int (Hz) | ≥ 100 | `12500` |
+| `vfo_fir_order_factor_N` | int | ≥ 2 | `2` |
+| `vfo_squelch_N` | int (dBFS) | Any integer | `-120` |
+| `vfo_squelch_mode_N` | string | `"Default"`, `"Auto"`, `"Manual"`, `"Auto Channel"` | `"Default"` |
+| `vfo_demod_N` | string | `"Default"`, `"None"`, `"FM"` | `"Default"` |
+| `vfo_iq_N` | string | `"Default"`, `"False"`, `"True"` | `"Default"` |
+
+### Remote control via HTTP (legacy)
+
+> **Note:** HTTP-based remote control via port 8081 is a legacy mechanism. The WebSocket interface above is the recommended approach and works in both GUI and headless modes without any extra server.
+
+The `settings.json` file can still be served and uploaded via miniserve on port 8081 when `en_remote_control: true` is set and the application is running in GUI mode. This option is disabled in headless mode.
+
+```bash
+# Download current settings
+curl http://KRAKEN_IP:8081/settings.json
+
+# Upload modified settings
 curl -F "path=@settings.json" http://KRAKEN_IP:8081/upload\?path\=/
 ```
 
-The DSP software would then notice the settings changes and apply them automatically.
+#### Middleware API (port 8042)
 
-#### Alternative via middleware
+The Node.js middleware also exposes a REST API for settings access:
 
-You can also use the middleware API to retrive and change the settings.json, the api is avaliable under `http://KRAKEN_IP:8042/settings` and works without enabling the remote mode mentioned in the software startup.
-
-Use a simple GET request to the endpoint to retrive the current settings in json format.
-To set a new settings file just send the json data as a POST request to the endpoint.
-
-A typical use would be the following:
-
-* GET request - retrive current settings
-* modify settings in json
-* POST request - save new settings to kraken
+```bash
+GET  http://KRAKEN_IP:8042/settings   # retrieve current settings JSON
+POST http://KRAKEN_IP:8042/settings   # send new settings JSON
+```
 
 
 ## For Contributors

--- a/_sdr/_signal_processing/kraken_sdr_signal_processor.py
+++ b/_sdr/_signal_processing/kraken_sdr_signal_processor.py
@@ -99,7 +99,7 @@ class SignalProcessor(threading.Thread):
 
         self.module_receiver = module_receiver
         self.data_que = data_que
-        self.en_spectrum = False
+        self.en_spectrum = True
         self.en_record = False
         self.wav_record_path = f"{shared_path}/records/fm"
         self.en_iq_files = False

--- a/_sdr/_signal_processing/kraken_sdr_signal_processor.py
+++ b/_sdr/_signal_processing/kraken_sdr_signal_processor.py
@@ -789,6 +789,30 @@ class SignalProcessor(threading.Thread):
                                 max_power_level_str,
                             )
 
+                        # WebSocket broadcast — one message per VFO, works for all output formats
+                        try:
+                            import kraken_ws_server as _ws
+                            for j, freq in enumerate(self.freq_list):
+                                _doa_log = self.doa_result_log_list[j] + np.abs(
+                                    np.min(self.doa_result_log_list[j])
+                                )
+                                _ws.broadcast_from_thread({
+                                    "type": "doa",
+                                    "timestamp": self.timestamp,
+                                    "bearing": 360 - self.theta_0_list[j],
+                                    "confidence": float(self.confidence_list[j]),
+                                    "power_db": float(self.max_power_level_list[j]),
+                                    "freq_hz": freq,
+                                    "antenna_arrangement": self.DOA_ant_alignment,
+                                    "latency_ms": self.latency,
+                                    "station_id": self.station_id,
+                                    "latitude": self.latitude,
+                                    "longitude": self.longitude,
+                                    "doa_spectrum": _doa_log.tolist(),
+                                })
+                        except Exception:
+                            pass
+
                         DOA_str = f"{self.theta_0_list[0]}"
                         confidence_str = f"{np.max(self.confidence_list[0]):.2f}"
                         max_power_level_str = f"{np.maximum(-100, self.max_power_level_list[0]):.1f}"

--- a/_ui/_web_interface/app.py
+++ b/_ui/_web_interface/app.py
@@ -34,6 +34,10 @@ app.layout = main.layout
 # It is workaround for splitting callbacks in separate files (run callbacks after layout)
 from callbacks import display_page, main, update_daq_params  # noqa: F401
 
+# Register the WebInterface as the handler for inbound WS commands so that
+# external clients can update settings via ws://host:8082/ws/kraken.
+kraken_ws_server.register_command_handler(web_interface.handle_ws_command)
+
 # Start the standalone WebSocket server immediately — pure stdlib, no Quart or
 # hypercorn required, completely independent of the dash_devices server.
 kraken_ws_server.start_server(host="0.0.0.0", port=8082)

--- a/_ui/_web_interface/app.py
+++ b/_ui/_web_interface/app.py
@@ -23,6 +23,8 @@ from maindash import app, spectrum_fig, waterfall_fig, web_interface
 
 # isort: on
 
+import threading
+
 import kraken_ws_server
 from utils import fetch_dsp_data, fetch_gps_data
 from views import main
@@ -32,17 +34,24 @@ app.layout = main.layout
 # It is workaround for splitting callbacks in separate files (run callbacks after layout)
 from callbacks import display_page, main, update_daq_params  # noqa: F401
 
-# Start the standalone WebSocket server on its own port/thread immediately.
-# This is independent of dash_devices so clients can connect and receive data
-# without any browser ever opening the GUI.
+# Start the standalone WebSocket server immediately — pure stdlib, no Quart or
+# hypercorn required, completely independent of the dash_devices server.
 kraken_ws_server.start_server(host="0.0.0.0", port=8082)
 
-# Start the data-pump timers unconditionally at module load time.
-# Previously these only started when the first browser client connected
-# (callback_connect).  Starting them here ensures the signal-processor queue
-# is always drained and WebSocket broadcasts always flow.
-fetch_dsp_data(app, web_interface, spectrum_fig, waterfall_fig)
-fetch_gps_data(app, web_interface)
+
+def _start_data_pumps():
+    """Start the data-pump timers after the Dash server has had time to init.
+
+    fetch_gps_data calls app.push_mods() immediately, which needs the Dash
+    server running.  A short delay avoids calling it before run_server() has
+    finished its own setup.
+    """
+    fetch_dsp_data(app, web_interface, spectrum_fig, waterfall_fig)
+    fetch_gps_data(app, web_interface)
+
+
+# 3-second delay gives app.run_server() time to start before push_mods fires.
+threading.Timer(3.0, _start_data_pumps).start()
 
 if __name__ == "__main__":
     # Debug mode does not work when the data interface is set to shared-memory

--- a/_ui/_web_interface/app.py
+++ b/_ui/_web_interface/app.py
@@ -23,12 +23,25 @@ from maindash import app
 
 # isort: on
 
+import asyncio
+
+import kraken_ws_server
 from views import main
 
 app.layout = main.layout
 
 # It is workaround for splitting callbacks in separate files (run callbacks after layout)
 from callbacks import display_page, main, update_daq_params  # noqa: F401
+
+# Register /ws/kraken on the underlying Quart server
+kraken_ws_server.register_ws_route(app.server)
+
+
+@app.server.before_serving
+async def _capture_event_loop():
+    """Store the running event loop so worker threads can schedule WS broadcasts."""
+    kraken_ws_server._event_loop = asyncio.get_event_loop()
+
 
 if __name__ == "__main__":
     # Debug mode does not work when the data interface is set to shared-memory

--- a/_ui/_web_interface/app.py
+++ b/_ui/_web_interface/app.py
@@ -19,13 +19,12 @@
 # - coding: utf-8 -*-
 
 # isort: off
-from maindash import app
+from maindash import app, spectrum_fig, waterfall_fig, web_interface
 
 # isort: on
 
-import asyncio
-
 import kraken_ws_server
+from utils import fetch_dsp_data, fetch_gps_data
 from views import main
 
 app.layout = main.layout
@@ -33,15 +32,17 @@ app.layout = main.layout
 # It is workaround for splitting callbacks in separate files (run callbacks after layout)
 from callbacks import display_page, main, update_daq_params  # noqa: F401
 
-# Register /ws/kraken on the underlying Quart server
-kraken_ws_server.register_ws_route(app.server)
+# Start the standalone WebSocket server on its own port/thread immediately.
+# This is independent of dash_devices so clients can connect and receive data
+# without any browser ever opening the GUI.
+kraken_ws_server.start_server(host="0.0.0.0", port=8082)
 
-
-@app.server.before_serving
-async def _capture_event_loop():
-    """Store the running event loop so worker threads can schedule WS broadcasts."""
-    kraken_ws_server._event_loop = asyncio.get_event_loop()
-
+# Start the data-pump timers unconditionally at module load time.
+# Previously these only started when the first browser client connected
+# (callback_connect).  Starting them here ensures the signal-processor queue
+# is always drained and WebSocket broadcasts always flow.
+fetch_dsp_data(app, web_interface, spectrum_fig, waterfall_fig)
+fetch_gps_data(app, web_interface)
 
 if __name__ == "__main__":
     # Debug mode does not work when the data interface is set to shared-memory

--- a/_ui/_web_interface/callbacks/display_page.py
+++ b/_ui/_web_interface/callbacks/display_page.py
@@ -27,17 +27,14 @@ def display_page(pathname):
     web_interface.pathname = pathname
 
     if pathname == "/" or pathname == "/init":
-        web_interface.module_signal_processor.en_spectrum = False
         return [generate_config_page_layout(web_interface), "header_active", "header_inactive", "header_inactive"]
     elif pathname == "/config":
-        web_interface.module_signal_processor.en_spectrum = False
         return [generate_config_page_layout(web_interface), "header_active", "header_inactive", "header_inactive"]
     elif pathname == "/spectrum":
         web_interface.module_signal_processor.en_spectrum = True
         web_interface.reset_spectrum_graph_flag = True
         return [spectrum_page.layout, "header_inactive", "header_active", "header_inactive"]
     elif pathname == "/doa":
-        web_interface.module_signal_processor.en_spectrum = False
         web_interface.reset_doa_graph_flag = True
         plot_doa(app, web_interface, doa_fig)
         return [generate_doa_page.layout, "header_inactive", "header_inactive", "header_active"]

--- a/_ui/_web_interface/callbacks/main.py
+++ b/_ui/_web_interface/callbacks/main.py
@@ -46,12 +46,11 @@ from variables import (
 # ============================================
 @app.callback_connect
 def func(client, connect):
-    if connect and len(app.clients) == 1:
-        fetch_dsp_data(app, web_interface, spectrum_fig, waterfall_fig)
-        fetch_gps_data(app, web_interface)
-    elif not connect and len(app.clients) == 0:
-        web_interface.dsp_timer.cancel()
-        web_interface.gps_timer.cancel()
+    # fetch_dsp_data and fetch_gps_data are started unconditionally at Quart
+    # startup (app.py before_serving hook) so that WebSocket clients receive
+    # data regardless of whether any browser has the GUI open.  Do not start
+    # or stop the timers here.
+    pass
 
 
 @app.callback_shared(

--- a/_ui/_web_interface/headless.py
+++ b/_ui/_web_interface/headless.py
@@ -1,0 +1,75 @@
+# KrakenSDR Signal Processor — headless entry point
+#
+# Starts the signal-processing pipeline and WebSocket server (port 8082)
+# without the Dash/Quart web GUI.  All data (DoA, spectrum, settings) is
+# streamed via the WebSocket, and parameters can be updated by sending
+# command messages to the same socket — no browser, no 8081 file server
+# required.
+#
+# Usage:
+#   python3 headless.py
+#
+# WebSocket endpoint:  ws://<host>:8082/ws/kraken
+#
+# Outbound message types (server → client):
+#   { "type": "doa",      "timestamp": <ms>, ... }
+#   { "type": "spectrum", "timestamp": <ms>, ... }
+#   { "type": "settings", "timestamp": <ms>, ... }
+#
+# Inbound command (client → server):
+#   {
+#     "type": "command",
+#     "action": "update_settings",
+#     "data": { <partial or full settings dict> }
+#   }
+#
+# - coding: utf-8 -*-
+
+import threading
+
+# variables.py inserts the receiver / signal-processor / ui paths into
+# sys.path, so it must be imported before any of those modules.
+import variables  # noqa: F401 (side-effect import)
+
+import kraken_ws_server
+from kraken_web_interface import WebInterface
+from utils import fetch_dsp_data, fetch_gps_data
+
+# ── bootstrap ─────────────────────────────────────────────────────────────────
+
+# Create the core pipeline: receiver + signal processor + settings watcher.
+# The signal processor thread starts inside WebInterface.__init__().
+web_interface = WebInterface()
+
+# Wire inbound WS commands to the web interface.
+kraken_ws_server.register_command_handler(web_interface.handle_ws_command)
+
+# Start the WebSocket server (port 8082) in a background daemon thread.
+kraken_ws_server.start_server(host="0.0.0.0", port=8082)
+
+
+def _start_data_pumps():
+    """Start the DSP and GPS data-pump timers.
+
+    Passing app=None skips all Dash push_mods calls — the pumps still drain
+    the signal-processor queues and broadcast data via WebSocket.
+    """
+    fetch_dsp_data(None, web_interface, None, None)
+    fetch_gps_data(None, web_interface)
+
+
+# Small delay so the signal processor has time to produce its first frame
+# before the pumps start polling.
+threading.Timer(3.0, _start_data_pumps).start()
+
+# ── run forever ───────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    import logging
+
+    logging.basicConfig(level=logging.INFO)
+    logging.getLogger(__name__).info(
+        "KrakenSDR headless mode running — WebSocket on ws://0.0.0.0:8082/ws/kraken"
+    )
+    # Block the main thread; all real work happens in daemon threads.
+    threading.Event().wait()

--- a/_ui/_web_interface/kraken_web_interface.py
+++ b/_ui/_web_interface/kraken_web_interface.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import queue
 import time
 
@@ -17,12 +18,13 @@ from variables import (
 
 # isort: on
 
+import variables
 from dash_devices.dependencies import Input
 from kraken_sdr_receiver import ReceiverRTLSDR
 
 # Import built-in modules
 from kraken_sdr_signal_processor import SignalProcessor
-from utils import read_config_file_dict, settings_change_watcher
+from utils import apply_settings_dict, read_config_file_dict, settings_change_watcher
 
 
 class WebInterface:
@@ -467,6 +469,65 @@ class WebInterface:
 
     def close(self):
         pass
+
+    def handle_ws_command(self, payload: dict):
+        """Process an inbound WebSocket command from an external client.
+
+        Expected format::
+
+            {
+                "type": "command",
+                "action": "update_settings",
+                "data": { <partial or full settings dict> }
+            }
+
+        The incoming ``data`` dict is merged over the current settings so
+        callers only need to send the keys they want to change.  Settings are
+        applied immediately to the signal processor (no 0.5 s poll delay) and
+        ``needs_refresh`` is set so the GUI form fields update on the next
+        Dash timer tick.
+        """
+        if payload.get("type") != "command":
+            return
+
+        action = payload.get("action")
+
+        if action == "update_settings":
+            incoming = payload.get("data", {})
+            if not incoming:
+                return
+
+            # Load current settings as the base so a partial update works.
+            try:
+                with open(settings_file_path, "r", encoding="utf-8") as f:
+                    current = json.load(f)
+            except Exception:
+                current = {}
+
+            merged = {**current, **incoming}
+            merged["ext_upd_flag"] = False
+
+            # Persist to disk.
+            with open(settings_file_path, "w", encoding="utf-8") as f:
+                json.dump(merged, f, indent=2)
+
+            # Advance the known-timestamp so the file watcher doesn't
+            # re-apply the same settings 0.5 s later.
+            new_mtime = os.path.getmtime(settings_file_path)
+            variables.dsp_settings = merged
+            variables.dsp_settings["timestamp"] = new_mtime
+
+            # Apply immediately — no waiting for the file-change poll.
+            apply_settings_dict(self, merged)
+
+            # Signal the Dash refresh timer to push all form fields to the GUI.
+            self.needs_refresh = True
+
+            # Broadcast the full updated settings to all WS subscribers.
+            self.save_configuration()
+            self.logger.info("Settings updated via WebSocket command")
+        else:
+            self.logger.warning("Unknown WS command action: %s", action)
 
     def config_daq_rf(self, f0, gain):
         """

--- a/_ui/_web_interface/kraken_web_interface.py
+++ b/_ui/_web_interface/kraken_web_interface.py
@@ -354,9 +354,12 @@ class WebInterface:
         with open(settings_file_path, "w") as outfile:
             json.dump(data, outfile, indent=2)
 
-        kraken_ws_server.broadcast_from_thread(
-            {"type": "settings", "timestamp": int(time.time() * 1000), **data}
-        )
+        ws_payload = {"type": "settings", "timestamp": int(time.time() * 1000), **data}
+        # Update the cache synchronously first — this works even at startup
+        # before the event loop exists, ensuring new WS clients always get a
+        # settings snapshot immediately on connect.
+        kraken_ws_server.cache_settings(ws_payload)
+        kraken_ws_server.broadcast_from_thread(ws_payload)
 
     def load_default_configuration(self):
         data = {}

--- a/_ui/_web_interface/kraken_web_interface.py
+++ b/_ui/_web_interface/kraken_web_interface.py
@@ -3,6 +3,7 @@ import logging
 import queue
 import time
 
+import kraken_ws_server
 import numpy as np
 
 # isort: off
@@ -352,6 +353,10 @@ class WebInterface:
 
         with open(settings_file_path, "w") as outfile:
             json.dump(data, outfile, indent=2)
+
+        kraken_ws_server.broadcast_from_thread(
+            {"type": "settings", "timestamp": int(time.time() * 1000), **data}
+        )
 
     def load_default_configuration(self):
         data = {}

--- a/_ui/_web_interface/kraken_ws_server.py
+++ b/_ui/_web_interface/kraken_ws_server.py
@@ -1,14 +1,19 @@
 """
-KrakenSDR WebSocket broadcast server.
+KrakenSDR WebSocket broadcast server — zero external dependencies.
 
-Runs in its own background daemon thread with a dedicated asyncio event loop,
-completely independent of the dash_devices / Quart server on port 8080.
-This means clients can connect and receive data immediately at application
+Implements the WebSocket protocol (RFC 6455) directly on top of Python's
+asyncio TCP server, so it works with whatever Python 3.x is installed on the
+KrakenSDR device without requiring Quart, hypercorn, websockets, or any other
+third-party package.
+
+The server runs in its own background daemon thread with a dedicated asyncio
+event loop, completely independent of the dash_devices / Quart server on
+port 8080.  Clients can connect and receive data immediately at application
 startup — no browser needs to be open.
 
-Endpoint
---------
-    ws://<host>:<WS_PORT>/ws/kraken          (default port 8082)
+Endpoint (default)
+------------------
+    ws://<host>:8082/ws/kraken
 
 Every message is a JSON object whose first key is 'type':
 
@@ -16,24 +21,23 @@ Every message is a JSON object whose first key is 'type':
     { "type": "spectrum", "timestamp": <epoch_ms>, ... }
     { "type": "settings", "timestamp": <epoch_ms>, ... }
 
-On connect the client immediately receives the last-known settings snapshot
-so it always has the current device configuration without waiting for a change.
+On connect the client immediately receives the last-known settings snapshot.
 
 Thread-safety
 -------------
 Signal-processor and fetch_dsp_data timer threads call broadcast_from_thread()
-which is a non-blocking, thread-safe fire-and-forget that schedules the
-async send onto the WS server's own event loop.
+which is a non-blocking fire-and-forget that schedules the async send onto the
+WS server's own event loop via asyncio.run_coroutine_threadsafe().
 """
 
 import asyncio
+import base64
+import hashlib
 import json
 import logging
+import struct
 import threading
 from typing import Optional
-
-from quart import Quart
-from quart import websocket as ws_ctx
 
 logger = logging.getLogger(__name__)
 
@@ -42,37 +46,132 @@ logger = logging.getLogger(__name__)
 # One asyncio.Queue per connected client.
 _ws_clients: set = set()
 
-# The event loop running inside the WS server thread.  Set by start_server()
-# before the serve loop begins; None until then.
+# The event loop running inside the WS server thread.
 _event_loop: Optional[asyncio.AbstractEventLoop] = None
 
 # Last settings payload as a serialised JSON string.  Written synchronously by
 # cache_settings() so it is available even before the server starts.
 _last_settings: Optional[str] = None
 
-# ── internal Quart app ────────────────────────────────────────────────────────
-
-_ws_app = Quart(__name__)
-_ws_app.logger.setLevel(logging.WARNING)
+# RFC 6455 magic GUID used to compute Sec-WebSocket-Accept
+_WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
 
-@_ws_app.websocket("/ws/kraken")
-async def _ws_kraken():
+# ── WebSocket protocol helpers ────────────────────────────────────────────────
+
+async def _do_handshake(reader: asyncio.StreamReader,
+                        writer: asyncio.StreamWriter) -> bool:
+    """Read the HTTP upgrade request and respond with 101."""
+    headers: dict = {}
+    try:
+        await reader.readline()  # request line — discard
+        while True:
+            raw = await reader.readline()
+            line = raw.decode(errors="replace").strip()
+            if not line:
+                break
+            if ": " in line:
+                k, v = line.split(": ", 1)
+                headers[k.lower()] = v
+    except Exception:
+        return False
+
+    ws_key = headers.get("sec-websocket-key", "")
+    if not ws_key:
+        return False
+
+    accept = base64.b64encode(
+        hashlib.sha1((ws_key + _WS_GUID).encode()).digest()
+    ).decode()
+
+    writer.write(
+        b"HTTP/1.1 101 Switching Protocols\r\n"
+        b"Upgrade: websocket\r\n"
+        b"Connection: Upgrade\r\n"
+        + f"Sec-WebSocket-Accept: {accept}\r\n\r\n".encode()
+    )
+    await writer.drain()
+    return True
+
+
+async def _send_text(writer: asyncio.StreamWriter, text: str) -> None:
+    """Send a single WebSocket text frame (opcode 0x1, FIN set)."""
+    payload = text.encode("utf-8")
+    length = len(payload)
+    if length <= 125:
+        header = bytes([0x81, length])
+    elif length <= 65535:
+        header = bytes([0x81, 126]) + struct.pack(">H", length)
+    else:
+        header = bytes([0x81, 127]) + struct.pack(">Q", length)
+    writer.write(header + payload)
+    await writer.drain()
+
+
+async def _drain_incoming(reader: asyncio.StreamReader) -> None:
+    """Read and discard all frames sent by the client.
+
+    Clients rarely send anything, but we must drain the TCP receive buffer to
+    prevent back-pressure from stalling the connection.  Also detects a clean
+    close frame (opcode 0x8).
+    """
+    try:
+        while True:
+            header = await reader.readexactly(2)
+            masked_len = header[1]
+            is_masked = bool(masked_len & 0x80)
+            length = masked_len & 0x7F
+            if length == 126:
+                length = struct.unpack(">H", await reader.readexactly(2))[0]
+            elif length == 127:
+                length = struct.unpack(">Q", await reader.readexactly(8))[0]
+            if is_masked:
+                await reader.readexactly(4)   # mask key — discard
+            if length:
+                await reader.readexactly(length)  # payload — discard
+            opcode = header[0] & 0x0F
+            if opcode == 0x8:  # close frame
+                break
+    except Exception:
+        pass
+
+
+# ── client handler ────────────────────────────────────────────────────────────
+
+async def _handle_client(reader: asyncio.StreamReader,
+                         writer: asyncio.StreamWriter) -> None:
+    if not await _do_handshake(reader, writer):
+        writer.close()
+        return
+
     q: asyncio.Queue = asyncio.Queue(maxsize=20)
     _ws_clients.add(q)
     logger.info("WS client connected (%d total)", len(_ws_clients))
-    try:
-        # Send cached settings snapshot immediately so the client has current
-        # device configuration without waiting for a settings-change event.
+
+    async def _send_loop() -> None:
         if _last_settings is not None:
-            await ws_ctx.send(_last_settings)
+            await _send_text(writer, _last_settings)
         while True:
             message = await q.get()
-            await ws_ctx.send(message)
-    except Exception:
-        pass
+            await _send_text(writer, message)
+
+    send_task = asyncio.ensure_future(_send_loop())
+    recv_task = asyncio.ensure_future(_drain_incoming(reader))
+
+    try:
+        done, pending = await asyncio.wait(
+            {send_task, recv_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for t in pending:
+            t.cancel()
     finally:
         _ws_clients.discard(q)
+        try:
+            writer.close()
+            await writer.wait_closed()
+        except Exception:
+            pass
         logger.info("WS client disconnected (%d total)", len(_ws_clients))
 
 
@@ -81,7 +180,7 @@ async def _ws_kraken():
 def cache_settings(payload: dict) -> None:
     """Synchronously cache the settings payload.
 
-    Called by save_configuration() *before* broadcast_from_thread() so the
+    Called by save_configuration() before broadcast_from_thread() so the
     snapshot is always current — even at startup before the event loop exists.
     """
     global _last_settings
@@ -89,10 +188,7 @@ def cache_settings(payload: dict) -> None:
 
 
 async def broadcast_to_ws(payload: dict) -> None:
-    """Coroutine: put a JSON message on every connected client's queue.
-
-    Uses put_nowait() so a slow client never blocks the pipeline.
-    """
+    """Put a JSON message on every connected client's queue (non-blocking)."""
     message = json.dumps(payload)
     slow_clients: set = set()
     for q in list(_ws_clients):
@@ -106,12 +202,7 @@ async def broadcast_to_ws(payload: dict) -> None:
 
 
 def broadcast_from_thread(payload: dict) -> None:
-    """Thread-safe, non-blocking broadcast.
-
-    Safe to call from any worker thread (signal processor, Timer callbacks).
-    Schedules broadcast_to_ws onto the WS server's event loop and returns
-    immediately.
-    """
+    """Thread-safe, non-blocking broadcast from any worker thread."""
     loop = _event_loop
     if loop is None or loop.is_closed():
         return
@@ -124,30 +215,26 @@ def broadcast_from_thread(payload: dict) -> None:
 def start_server(host: str = "0.0.0.0", port: int = 8082) -> None:
     """Start the WebSocket server in a background daemon thread.
 
-    Uses hypercorn (Quart's bundled ASGI server) with a fresh asyncio event
-    loop, entirely separate from the dash_devices server on port 8080.
-    Returns immediately; the server runs until the process exits.
+    Uses only Python stdlib — no Quart, hypercorn, or websockets package
+    required.  Returns immediately; the server runs until the process exits.
     """
-    from hypercorn.asyncio import serve
-    from hypercorn.config import Config
-
     def _run() -> None:
         global _event_loop
-
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         _event_loop = loop
 
-        config = Config()
-        config.bind = [f"{host}:{port}"]
-        config.loglevel = "WARNING"
+        async def _serve() -> None:
+            server = await asyncio.start_server(_handle_client, host, port)
+            logger.info(
+                "KrakenSDR WebSocket server listening on ws://%s:%d/ws/kraken",
+                host, port,
+            )
+            async with server:
+                await server.serve_forever()
 
-        logger.info(
-            "KrakenSDR WebSocket server listening on ws://%s:%d/ws/kraken",
-            host, port,
-        )
         try:
-            loop.run_until_complete(serve(_ws_app, config))
+            loop.run_until_complete(_serve())
         except Exception:
             logger.exception("WebSocket server stopped unexpectedly")
 
@@ -156,5 +243,5 @@ def start_server(host: str = "0.0.0.0", port: int = 8082) -> None:
 
 
 def register_ws_route(_quart_app) -> None:
-    """No-op — kept so existing call sites don't break during transition."""
+    """No-op — kept so any stale call sites don't raise AttributeError."""
     pass

--- a/_ui/_web_interface/kraken_ws_server.py
+++ b/_ui/_web_interface/kraken_ws_server.py
@@ -37,7 +37,7 @@ import json
 import logging
 import struct
 import threading
-from typing import Optional
+from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +52,10 @@ _event_loop: Optional[asyncio.AbstractEventLoop] = None
 # Last settings payload as a serialised JSON string.  Written synchronously by
 # cache_settings() so it is available even before the server starts.
 _last_settings: Optional[str] = None
+
+# Optional callback invoked with a parsed dict whenever a client sends a
+# JSON command frame.  Register via register_command_handler().
+_command_handler: Optional[Callable[[dict], None]] = None
 
 # RFC 6455 magic GUID used to compute Sec-WebSocket-Accept
 _WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
@@ -108,30 +112,49 @@ async def _send_text(writer: asyncio.StreamWriter, text: str) -> None:
     await writer.drain()
 
 
-async def _drain_incoming(reader: asyncio.StreamReader) -> None:
-    """Read and discard all frames sent by the client.
+async def _receive_and_dispatch(reader: asyncio.StreamReader) -> None:
+    """Read frames sent by the client, unmask them, and dispatch commands.
 
-    Clients rarely send anything, but we must drain the TCP receive buffer to
-    prevent back-pressure from stalling the connection.  Also detects a clean
-    close frame (opcode 0x8).
+    Client→server frames are always masked (RFC 6455 §5.3).  Text frames
+    (opcode 0x1) are decoded as UTF-8 JSON and forwarded to the registered
+    command handler.  All other frame types are consumed silently so TCP
+    back-pressure never stalls the connection.  A close frame (opcode 0x8)
+    terminates the loop.
     """
     try:
         while True:
             header = await reader.readexactly(2)
+            opcode = header[0] & 0x0F
             masked_len = header[1]
             is_masked = bool(masked_len & 0x80)
             length = masked_len & 0x7F
+
             if length == 126:
                 length = struct.unpack(">H", await reader.readexactly(2))[0]
             elif length == 127:
                 length = struct.unpack(">Q", await reader.readexactly(8))[0]
+
+            mask_key = b""
             if is_masked:
-                await reader.readexactly(4)   # mask key — discard
+                mask_key = await reader.readexactly(4)
+
+            payload = b""
             if length:
-                await reader.readexactly(length)  # payload — discard
-            opcode = header[0] & 0x0F
+                payload = await reader.readexactly(length)
+
+            # Unmask payload (XOR each byte with cycling mask key)
+            if is_masked and mask_key:
+                payload = bytes(b ^ mask_key[i % 4] for i, b in enumerate(payload))
+
             if opcode == 0x8:  # close frame
                 break
+            elif opcode == 0x1 and _command_handler is not None:  # text frame
+                try:
+                    data = json.loads(payload.decode("utf-8"))
+                    loop = asyncio.get_event_loop()
+                    await loop.run_in_executor(None, _command_handler, data)
+                except Exception as exc:
+                    logger.warning("WS command error: %s", exc)
     except Exception:
         pass
 
@@ -156,7 +179,7 @@ async def _handle_client(reader: asyncio.StreamReader,
             await _send_text(writer, message)
 
     send_task = asyncio.ensure_future(_send_loop())
-    recv_task = asyncio.ensure_future(_drain_incoming(reader))
+    recv_task = asyncio.ensure_future(_receive_and_dispatch(reader))
 
     try:
         done, pending = await asyncio.wait(
@@ -176,6 +199,17 @@ async def _handle_client(reader: asyncio.StreamReader,
 
 
 # ── public API ────────────────────────────────────────────────────────────────
+
+def register_command_handler(fn: Callable[[dict], None]) -> None:
+    """Register a callable that receives parsed JSON dicts from WS clients.
+
+    Called once at startup (from app.py or headless.py) to wire inbound
+    commands to the WebInterface.  The callable is invoked in a thread-pool
+    executor so it may safely perform blocking I/O.
+    """
+    global _command_handler
+    _command_handler = fn
+
 
 def cache_settings(payload: dict) -> None:
     """Synchronously cache the settings payload.

--- a/_ui/_web_interface/kraken_ws_server.py
+++ b/_ui/_web_interface/kraken_ws_server.py
@@ -1,42 +1,97 @@
 """
-WebSocket server for KrakenSDR real-time data broadcasting.
+KrakenSDR WebSocket broadcast server.
 
-Clients connect to  ws://<host>:8080/ws/kraken  and receive newline-delimited
-JSON messages.  Every message has a 'type' field as its first key so clients
-can route messages without inspecting the full payload:
+Runs in its own background daemon thread with a dedicated asyncio event loop,
+completely independent of the dash_devices / Quart server on port 8080.
+This means clients can connect and receive data immediately at application
+startup — no browser needs to be open.
+
+Endpoint
+--------
+    ws://<host>:<WS_PORT>/ws/kraken          (default port 8082)
+
+Every message is a JSON object whose first key is 'type':
 
     { "type": "doa",      "timestamp": <epoch_ms>, ... }
     { "type": "spectrum", "timestamp": <epoch_ms>, ... }
     { "type": "settings", "timestamp": <epoch_ms>, ... }
 
+On connect the client immediately receives the last-known settings snapshot
+so it always has the current device configuration without waiting for a change.
+
 Thread-safety
 -------------
-The Quart event loop runs in the main thread.  The signal processor and the
-fetch_dsp_data timer both run in worker threads.  Use broadcast_from_thread()
-from those contexts; it schedules the async coroutine onto the event loop via
-asyncio.run_coroutine_threadsafe().
+Signal-processor and fetch_dsp_data timer threads call broadcast_from_thread()
+which is a non-blocking, thread-safe fire-and-forget that schedules the
+async send onto the WS server's own event loop.
 """
 
 import asyncio
 import json
 import logging
+import threading
 from typing import Optional
+
+from quart import Quart
+from quart import websocket as ws_ctx
 
 logger = logging.getLogger(__name__)
 
-# One asyncio.Queue per connected WebSocket client.
+# ── shared state ──────────────────────────────────────────────────────────────
+
+# One asyncio.Queue per connected client.
 _ws_clients: set = set()
 
-# Set by the before_serving hook in app.py once the Quart event loop is live.
+# The event loop running inside the WS server thread.  Set by start_server()
+# before the serve loop begins; None until then.
 _event_loop: Optional[asyncio.AbstractEventLoop] = None
+
+# Last settings payload as a serialised JSON string.  Written synchronously by
+# cache_settings() so it is available even before the server starts.
+_last_settings: Optional[str] = None
+
+# ── internal Quart app ────────────────────────────────────────────────────────
+
+_ws_app = Quart(__name__)
+_ws_app.logger.setLevel(logging.WARNING)
+
+
+@_ws_app.websocket("/ws/kraken")
+async def _ws_kraken():
+    q: asyncio.Queue = asyncio.Queue(maxsize=20)
+    _ws_clients.add(q)
+    logger.info("WS client connected (%d total)", len(_ws_clients))
+    try:
+        # Send cached settings snapshot immediately so the client has current
+        # device configuration without waiting for a settings-change event.
+        if _last_settings is not None:
+            await ws_ctx.send(_last_settings)
+        while True:
+            message = await q.get()
+            await ws_ctx.send(message)
+    except Exception:
+        pass
+    finally:
+        _ws_clients.discard(q)
+        logger.info("WS client disconnected (%d total)", len(_ws_clients))
+
+
+# ── public API ────────────────────────────────────────────────────────────────
+
+def cache_settings(payload: dict) -> None:
+    """Synchronously cache the settings payload.
+
+    Called by save_configuration() *before* broadcast_from_thread() so the
+    snapshot is always current — even at startup before the event loop exists.
+    """
+    global _last_settings
+    _last_settings = json.dumps(payload)
 
 
 async def broadcast_to_ws(payload: dict) -> None:
-    """Coroutine: serialise payload and put it on every connected client's queue.
+    """Coroutine: put a JSON message on every connected client's queue.
 
-    Uses put_nowait() so that a slow or stalled client is never allowed to
-    block the signal-processing pipeline.  If a client's queue is full the
-    message is silently dropped for that client.
+    Uses put_nowait() so a slow client never blocks the pipeline.
     """
     message = json.dumps(payload)
     slow_clients: set = set()
@@ -51,10 +106,11 @@ async def broadcast_to_ws(payload: dict) -> None:
 
 
 def broadcast_from_thread(payload: dict) -> None:
-    """Thread-safe wrapper around broadcast_to_ws.
+    """Thread-safe, non-blocking broadcast.
 
-    Safe to call from any non-async thread (signal processor, Timer callbacks).
-    Returns immediately; the actual send is scheduled on the Quart event loop.
+    Safe to call from any worker thread (signal processor, Timer callbacks).
+    Schedules broadcast_to_ws onto the WS server's event loop and returns
+    immediately.
     """
     loop = _event_loop
     if loop is None or loop.is_closed():
@@ -65,25 +121,40 @@ def broadcast_from_thread(payload: dict) -> None:
         pass
 
 
-def register_ws_route(quart_app) -> None:
-    """Register the /ws/kraken WebSocket endpoint on the supplied Quart app.
+def start_server(host: str = "0.0.0.0", port: int = 8082) -> None:
+    """Start the WebSocket server in a background daemon thread.
 
-    Call this from app.py *after* importing the Dash app but *before*
-    app.run_server(), passing app.server (the underlying Quart instance).
+    Uses hypercorn (Quart's bundled ASGI server) with a fresh asyncio event
+    loop, entirely separate from the dash_devices server on port 8080.
+    Returns immediately; the server runs until the process exits.
     """
-    from quart import websocket as ws_ctx  # imported here to avoid top-level dep
+    from hypercorn.asyncio import serve
+    from hypercorn.config import Config
 
-    @quart_app.websocket("/ws/kraken")
-    async def ws_kraken():
-        q: asyncio.Queue = asyncio.Queue(maxsize=20)
-        _ws_clients.add(q)
-        logger.info("WS client connected (%d total)", len(_ws_clients))
+    def _run() -> None:
+        global _event_loop
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        _event_loop = loop
+
+        config = Config()
+        config.bind = [f"{host}:{port}"]
+        config.loglevel = "WARNING"
+
+        logger.info(
+            "KrakenSDR WebSocket server listening on ws://%s:%d/ws/kraken",
+            host, port,
+        )
         try:
-            while True:
-                message = await q.get()
-                await ws_ctx.send(message)
+            loop.run_until_complete(serve(_ws_app, config))
         except Exception:
-            pass
-        finally:
-            _ws_clients.discard(q)
-            logger.info("WS client disconnected (%d total)", len(_ws_clients))
+            logger.exception("WebSocket server stopped unexpectedly")
+
+    t = threading.Thread(target=_run, daemon=True, name="kraken-ws-server")
+    t.start()
+
+
+def register_ws_route(_quart_app) -> None:
+    """No-op — kept so existing call sites don't break during transition."""
+    pass

--- a/_ui/_web_interface/kraken_ws_server.py
+++ b/_ui/_web_interface/kraken_ws_server.py
@@ -1,0 +1,89 @@
+"""
+WebSocket server for KrakenSDR real-time data broadcasting.
+
+Clients connect to  ws://<host>:8080/ws/kraken  and receive newline-delimited
+JSON messages.  Every message has a 'type' field as its first key so clients
+can route messages without inspecting the full payload:
+
+    { "type": "doa",      "timestamp": <epoch_ms>, ... }
+    { "type": "spectrum", "timestamp": <epoch_ms>, ... }
+    { "type": "settings", "timestamp": <epoch_ms>, ... }
+
+Thread-safety
+-------------
+The Quart event loop runs in the main thread.  The signal processor and the
+fetch_dsp_data timer both run in worker threads.  Use broadcast_from_thread()
+from those contexts; it schedules the async coroutine onto the event loop via
+asyncio.run_coroutine_threadsafe().
+"""
+
+import asyncio
+import json
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# One asyncio.Queue per connected WebSocket client.
+_ws_clients: set = set()
+
+# Set by the before_serving hook in app.py once the Quart event loop is live.
+_event_loop: Optional[asyncio.AbstractEventLoop] = None
+
+
+async def broadcast_to_ws(payload: dict) -> None:
+    """Coroutine: serialise payload and put it on every connected client's queue.
+
+    Uses put_nowait() so that a slow or stalled client is never allowed to
+    block the signal-processing pipeline.  If a client's queue is full the
+    message is silently dropped for that client.
+    """
+    message = json.dumps(payload)
+    slow_clients: set = set()
+    for q in list(_ws_clients):
+        try:
+            q.put_nowait(message)
+        except asyncio.QueueFull:
+            slow_clients.add(q)
+        except Exception:
+            slow_clients.add(q)
+    _ws_clients.difference_update(slow_clients)
+
+
+def broadcast_from_thread(payload: dict) -> None:
+    """Thread-safe wrapper around broadcast_to_ws.
+
+    Safe to call from any non-async thread (signal processor, Timer callbacks).
+    Returns immediately; the actual send is scheduled on the Quart event loop.
+    """
+    loop = _event_loop
+    if loop is None or loop.is_closed():
+        return
+    try:
+        asyncio.run_coroutine_threadsafe(broadcast_to_ws(payload), loop)
+    except RuntimeError:
+        pass
+
+
+def register_ws_route(quart_app) -> None:
+    """Register the /ws/kraken WebSocket endpoint on the supplied Quart app.
+
+    Call this from app.py *after* importing the Dash app but *before*
+    app.run_server(), passing app.server (the underlying Quart instance).
+    """
+    from quart import websocket as ws_ctx  # imported here to avoid top-level dep
+
+    @quart_app.websocket("/ws/kraken")
+    async def ws_kraken():
+        q: asyncio.Queue = asyncio.Queue(maxsize=20)
+        _ws_clients.add(q)
+        logger.info("WS client connected (%d total)", len(_ws_clients))
+        try:
+            while True:
+                message = await q.get()
+                await ws_ctx.send(message)
+        except Exception:
+            pass
+        finally:
+            _ws_clients.discard(q)
+            logger.info("WS client disconnected (%d total)", len(_ws_clients))

--- a/_ui/_web_interface/utils.py
+++ b/_ui/_web_interface/utils.py
@@ -219,11 +219,12 @@ def fetch_dsp_data(app, web_interface, spectrum_fig, waterfall_fig):
             elif data_entry[0] == "DoA Squelch":
                 web_interface.squelch_update = data_entry[1].copy()
             elif data_entry[0] == "VFO-0 Frequency":
-                app.push_mods(
-                    {
-                        "vfo_0_freq": {"value": data_entry[1] * HZ_TO_MHZ},
-                    }
-                )
+                if app is not None:
+                    app.push_mods(
+                        {
+                            "vfo_0_freq": {"value": data_entry[1] * HZ_TO_MHZ},
+                        }
+                    )
             else:
                 web_interface.logger.warning("Unknown data entry: {:s}".format(data_entry[0]))
     except queue.Empty:
@@ -233,32 +234,160 @@ def fetch_dsp_data(app, web_interface, spectrum_fig, waterfall_fig):
         pass
         # Handle task here and call q.task_done()
 
-    if (
-        web_interface.pathname == "/config" or web_interface.pathname == "/" or web_interface.pathname == "/init"
-    ) and daq_status_update_flag:
-        update_daq_status(app, web_interface)
-    elif web_interface.pathname == "/spectrum" and spectrum_update_flag:
-        plot_spectrum(app, web_interface, spectrum_fig, waterfall_fig)
-    # or (web_interface.pathname == "/doa" and
-    # web_interface.reset_doa_graph_flag):
-    elif web_interface.pathname == "/doa" and doa_update_flag:
-        plot_doa(app, web_interface, doa_fig)
+    if app is not None:
+        if (
+            web_interface.pathname == "/config" or web_interface.pathname == "/" or web_interface.pathname == "/init"
+        ) and daq_status_update_flag:
+            update_daq_status(app, web_interface)
+        elif web_interface.pathname == "/spectrum" and spectrum_update_flag:
+            plot_spectrum(app, web_interface, spectrum_fig, waterfall_fig)
+        # or (web_interface.pathname == "/doa" and
+        # web_interface.reset_doa_graph_flag):
+        elif web_interface.pathname == "/doa" and doa_update_flag:
+            plot_doa(app, web_interface, doa_fig)
 
     web_interface.dsp_timer = Timer(0.01, fetch_dsp_data, args=(app, web_interface, spectrum_fig, waterfall_fig))
     web_interface.dsp_timer.start()
 
 
 def fetch_gps_data(app, web_interface):
-    app.push_mods(
-        {
-            "body_gps_latitude": {"children": web_interface.module_signal_processor.latitude},
-            "body_gps_longitude": {"children": web_interface.module_signal_processor.longitude},
-            "body_gps_heading": {"children": web_interface.module_signal_processor.heading},
-        }
-    )
+    if app is not None:
+        app.push_mods(
+            {
+                "body_gps_latitude": {"children": web_interface.module_signal_processor.latitude},
+                "body_gps_longitude": {"children": web_interface.module_signal_processor.longitude},
+                "body_gps_heading": {"children": web_interface.module_signal_processor.heading},
+            }
+        )
 
     web_interface.gps_timer = Timer(1, fetch_gps_data, args=(app, web_interface))
     web_interface.gps_timer.start()
+
+
+def apply_settings_dict(web_interface, dsp_settings):
+    """Apply a settings dict directly to the web_interface and signal processor.
+
+    This is the authoritative settings-application logic, shared by both the
+    file-change watcher and the WebSocket command handler so that settings sent
+    via WS take effect immediately without waiting for the 0.5 s poll cycle.
+    """
+    center_freq = float(dsp_settings.get("center_freq", 100.0))
+    gain = (
+        float(dsp_settings.get("uniform_gain", 1.4))
+        if dsp_settings.get("uniform_gain", 1.4) != "Auto"
+        else AUTO_GAIN_VALUE
+    )
+
+    web_interface.en_system_control = [1] if dsp_settings.get("en_system_control", False) else []
+    web_interface.en_beta_features = [1] if dsp_settings.get("en_beta_features", False) else []
+
+    web_interface.module_signal_processor.en_DOA_estimation = dsp_settings.get("en_doa", 0)
+    web_interface.module_signal_processor.DOA_decorrelation_method = dsp_settings.get("doa_decorrelation_method", 0)
+
+    web_interface.module_signal_processor.DOA_ant_alignment = dsp_settings.get("ant_arrangement", "ULA")
+    web_interface.ant_spacing_meters = float(dsp_settings.get("ant_spacing_meters", 0.5))
+
+    wavelength = 300 / web_interface.daq_center_freq
+    if web_interface.module_signal_processor.DOA_ant_alignment == "UCA":
+        web_interface.module_signal_processor.DOA_UCA_radius_m = web_interface.ant_spacing_meters
+        inter_elem_spacing = (
+            np.sqrt(2)
+            * web_interface.ant_spacing_meters
+            * np.sqrt(1 - np.cos(np.deg2rad(360 / web_interface.module_signal_processor.channel_number)))
+        )
+        web_interface.module_signal_processor.DOA_inter_elem_space = inter_elem_spacing / wavelength
+    else:
+        web_interface.module_signal_processor.DOA_UCA_radius_m = np.Infinity
+        web_interface.module_signal_processor.DOA_inter_elem_space = web_interface.ant_spacing_meters / wavelength
+
+    web_interface.custom_array_x_meters = np.float_(
+        dsp_settings.get("custom_array_x_meters", "0.1,0.2,0.3,0.4,0.5").split(",")
+    )
+    web_interface.custom_array_y_meters = np.float_(
+        dsp_settings.get("custom_array_y_meters", "0.1,0.2,0.3,0.4,0.5").split(",")
+    )
+    web_interface.module_signal_processor.custom_array_x = web_interface.custom_array_x_meters / (
+        300 / web_interface.module_receiver.daq_center_freq
+    )
+    web_interface.module_signal_processor.custom_array_y = web_interface.custom_array_y_meters / (
+        300 / web_interface.module_receiver.daq_center_freq
+    )
+
+    # Station Information
+    web_interface.module_signal_processor.station_id = dsp_settings.get("station_id", "NO-CALL")
+    web_interface.location_source = dsp_settings.get("location_source", "None")
+    web_interface.module_signal_processor.latitude = dsp_settings.get("latitude", 0.0)
+    web_interface.module_signal_processor.longitude = dsp_settings.get("longitude", 0.0)
+    web_interface.module_signal_processor.heading = dsp_settings.get("heading", 0.0)
+    web_interface.module_signal_processor.krakenpro_key = dsp_settings.get("krakenpro_key", 0.0)
+    web_interface.mapping_server_url = dsp_settings.get("mapping_server_url", DEFAULT_MAPPING_SERVER_ENDPOINT)
+    web_interface.module_signal_processor.RDF_mapper_server = dsp_settings.get(
+        "rdf_mapper_server", "http://RDF_MAPPER_SERVER.com/save.php"
+    )
+    web_interface.module_signal_processor.DOA_data_format = dsp_settings.get("doa_data_format", "Kraken App")
+
+    # VFO Configuration
+    web_interface.module_signal_processor.spectrum_fig_type = dsp_settings.get("spectrum_calculation", "Single")
+    web_interface.module_signal_processor.vfo_mode = dsp_settings.get("vfo_mode", "Standard")
+    web_interface.module_signal_processor.vfo_default_squelch_mode = dsp_settings.get(
+        "vfo_default_squelch_mode", "Auto"
+    )
+    web_interface.module_signal_processor.vfo_default_demod = dsp_settings.get("vfo_default_demod", "None")
+    web_interface.module_signal_processor.vfo_default_iq = dsp_settings.get("vfo_default_iq", "False")
+    web_interface.module_signal_processor.max_demod_timeout = int(dsp_settings.get("max_demod_timeout", 60))
+    web_interface.module_signal_processor.dsp_decimation = int(dsp_settings.get("dsp_decimation", 0))
+    web_interface.module_signal_processor.active_vfos = int(dsp_settings.get("active_vfos", 0))
+    web_interface.module_signal_processor.output_vfo = int(dsp_settings.get("output_vfo", 0))
+    web_interface.compass_offset = dsp_settings.get("compass_offset", 0)
+    web_interface.module_signal_processor.compass_offset = web_interface.compass_offset
+    web_interface.module_signal_processor.optimize_short_bursts = dsp_settings.get("en_optimize_short_bursts", 0)
+    web_interface.module_signal_processor.en_peak_hold = dsp_settings.get("en_peak_hold", 0)
+
+    for i in range(web_interface.module_signal_processor.max_vfos):
+        web_interface.module_signal_processor.vfo_bw[i] = int(dsp_settings.get("vfo_bw_" + str(i), 0))
+        web_interface.module_signal_processor.vfo_fir_order_factor[i] = int(
+            dsp_settings.get("vfo_fir_order_factor_" + str(i), DEFAULT_VFO_FIR_ORDER_FACTOR)
+        )
+        web_interface.module_signal_processor.vfo_freq[i] = float(dsp_settings.get("vfo_freq_" + str(i), 0))
+        web_interface.module_signal_processor.vfo_squelch_mode[i] = dsp_settings.get(
+            "vfo_squelch_mode_" + str(i), "Default"
+        )
+        web_interface.module_signal_processor.vfo_squelch[i] = int(dsp_settings.get("vfo_squelch_" + str(i), 0))
+        web_interface.module_signal_processor.vfo_demod[i] = dsp_settings.get("vfo_demod_" + str(i), "Default")
+        web_interface.module_signal_processor.vfo_iq[i] = dsp_settings.get("vfo_iq_" + str(i), "Default")
+
+    web_interface.module_signal_processor.DOA_algorithm = dsp_settings.get("doa_method", "MUSIC")
+    web_interface.module_signal_processor.DOA_expected_num_of_sources = dsp_settings.get("expected_num_of_sources", 1)
+    web_interface._doa_fig_type = dsp_settings.get("doa_fig_type", "Linear")
+    web_interface.module_signal_processor.doa_measure = web_interface._doa_fig_type
+    web_interface.module_signal_processor.ula_direction = dsp_settings.get("ula_direction", "Both")
+    web_interface.module_signal_processor.array_offset = int(dsp_settings.get("array_offset", 0))
+
+    freq_delta = web_interface.daq_center_freq - center_freq
+    gain_delta = web_interface.module_receiver.daq_rx_gain - gain
+
+    if abs(freq_delta) > 0.001 or abs(gain_delta) > 0.001:
+        web_interface.daq_center_freq = center_freq
+        web_interface.config_daq_rf(center_freq, gain)
+        for i in range(web_interface.module_signal_processor.max_vfos):
+            half_band_width = (web_interface.module_signal_processor.vfo_bw[i] / 10**6) / 2
+            min_freq = web_interface.daq_center_freq - web_interface.daq_fs / 2 + half_band_width
+            max_freq = web_interface.daq_center_freq + web_interface.daq_fs / 2 - half_band_width
+            if min_freq > (web_interface.module_signal_processor.vfo_freq[i] / 10**6) or max_freq < (
+                web_interface.module_signal_processor.vfo_freq[i] / 10**6
+            ):
+                web_interface.module_signal_processor.vfo_freq[i] = web_interface.module_receiver.daq_center_freq
+
+        wavelength = 300 / web_interface.daq_center_freq
+        if web_interface.module_signal_processor.DOA_ant_alignment == "UCA":
+            inter_elem_spacing = (
+                np.sqrt(2)
+                * web_interface.ant_spacing_meters
+                * np.sqrt(1 - np.cos(np.deg2rad(360 / web_interface.module_signal_processor.channel_number)))
+            )
+            web_interface.module_signal_processor.DOA_inter_elem_space = inter_elem_spacing / wavelength
+        else:
+            web_interface.module_signal_processor.DOA_inter_elem_space = web_interface.ant_spacing_meters / wavelength
 
 
 def settings_change_watcher(web_interface, settings_file_path, last_attempt_failed=False):
@@ -281,150 +410,7 @@ def settings_change_watcher(web_interface, settings_file_path, last_attempt_fail
                 variables.dsp_settings["timestamp"] = last_changed_time
                 last_attempt_failed = False
 
-                center_freq = float(dsp_settings.get("center_freq", 100.0))
-                gain = (
-                    float(dsp_settings.get("uniform_gain", 1.4))
-                    if dsp_settings.get("uniform_gain", 1.4) != "Auto"
-                    else AUTO_GAIN_VALUE
-                )
-
-                web_interface.en_system_control = [1] if dsp_settings.get("en_system_control", False) else []
-                web_interface.en_beta_features = [1] if dsp_settings.get("en_beta_features", False) else []
-
-                web_interface.module_signal_processor.en_DOA_estimation = dsp_settings.get("en_doa", 0)
-                web_interface.module_signal_processor.DOA_decorrelation_method = dsp_settings.get(
-                    "doa_decorrelation_method", 0
-                )
-
-                web_interface.module_signal_processor.DOA_ant_alignment = dsp_settings.get("ant_arrangement", "ULA")
-                web_interface.ant_spacing_meters = float(dsp_settings.get("ant_spacing_meters", 0.5))
-
-                wavelength = 300 / web_interface.daq_center_freq
-                if web_interface.module_signal_processor.DOA_ant_alignment == "UCA":
-                    web_interface.module_signal_processor.DOA_UCA_radius_m = web_interface.ant_spacing_meters
-                    # Convert RADIUS to INTERELEMENT SPACING
-                    inter_elem_spacing = (
-                        np.sqrt(2)
-                        * web_interface.ant_spacing_meters
-                        * np.sqrt(1 - np.cos(np.deg2rad(360 / web_interface.module_signal_processor.channel_number)))
-                    )
-                    web_interface.module_signal_processor.DOA_inter_elem_space = inter_elem_spacing / wavelength
-                else:
-                    web_interface.module_signal_processor.DOA_UCA_radius_m = np.Infinity
-                    web_interface.module_signal_processor.DOA_inter_elem_space = (
-                        web_interface.ant_spacing_meters / wavelength
-                    )
-
-                web_interface.custom_array_x_meters = np.float_(
-                    dsp_settings.get("custom_array_x_meters", "0.1,0.2,0.3,0.4,0.5").split(",")
-                )
-                web_interface.custom_array_y_meters = np.float_(
-                    dsp_settings.get("custom_array_y_meters", "0.1,0.2,0.3,0.4,0.5").split(",")
-                )
-                web_interface.module_signal_processor.custom_array_x = web_interface.custom_array_x_meters / (
-                    300 / web_interface.module_receiver.daq_center_freq
-                )
-                web_interface.module_signal_processor.custom_array_y = web_interface.custom_array_y_meters / (
-                    300 / web_interface.module_receiver.daq_center_freq
-                )
-
-                # Station Information
-                web_interface.module_signal_processor.station_id = dsp_settings.get("station_id", "NO-CALL")
-                web_interface.location_source = dsp_settings.get("location_source", "None")
-                web_interface.module_signal_processor.latitude = dsp_settings.get("latitude", 0.0)
-                web_interface.module_signal_processor.longitude = dsp_settings.get("longitude", 0.0)
-                web_interface.module_signal_processor.heading = dsp_settings.get("heading", 0.0)
-                web_interface.module_signal_processor.krakenpro_key = dsp_settings.get("krakenpro_key", 0.0)
-                web_interface.mapping_server_url = dsp_settings.get(
-                    "mapping_server_url", DEFAULT_MAPPING_SERVER_ENDPOINT
-                )
-                web_interface.module_signal_processor.RDF_mapper_server = dsp_settings.get(
-                    "rdf_mapper_server", "http://RDF_MAPPER_SERVER.com/save.php"
-                )
-                web_interface.module_signal_processor.DOA_data_format = dsp_settings.get(
-                    "doa_data_format", "Kraken App"
-                )
-
-                # VFO Configuration
-                web_interface.module_signal_processor.spectrum_fig_type = dsp_settings.get(
-                    "spectrum_calculation", "Single"
-                )
-                web_interface.module_signal_processor.vfo_mode = dsp_settings.get("vfo_mode", "Standard")
-                web_interface.module_signal_processor.vfo_default_squelch_mode = dsp_settings.get(
-                    "vfo_default_squelch_mode", "Auto"
-                )
-                web_interface.module_signal_processor.vfo_default_demod = dsp_settings.get("vfo_default_demod", "None")
-                web_interface.module_signal_processor.vfo_default_iq = dsp_settings.get("vfo_default_iq", "False")
-                web_interface.module_signal_processor.max_demod_timeout = int(dsp_settings.get("max_demod_timeout", 60))
-                web_interface.module_signal_processor.dsp_decimation = int(dsp_settings.get("dsp_decimation", 0))
-                web_interface.module_signal_processor.active_vfos = int(dsp_settings.get("active_vfos", 0))
-                web_interface.module_signal_processor.output_vfo = int(dsp_settings.get("output_vfo", 0))
-                web_interface.compass_offset = dsp_settings.get("compass_offset", 0)
-                web_interface.module_signal_processor.compass_offset = web_interface.compass_offset
-                web_interface.module_signal_processor.optimize_short_bursts = dsp_settings.get(
-                    "en_optimize_short_bursts", 0
-                )
-                web_interface.module_signal_processor.en_peak_hold = dsp_settings.get("en_peak_hold", 0)
-
-                for i in range(web_interface.module_signal_processor.max_vfos):
-                    web_interface.module_signal_processor.vfo_bw[i] = int(dsp_settings.get("vfo_bw_" + str(i), 0))
-                    web_interface.module_signal_processor.vfo_fir_order_factor[i] = int(
-                        dsp_settings.get("vfo_fir_order_factor_" + str(i), DEFAULT_VFO_FIR_ORDER_FACTOR)
-                    )
-                    web_interface.module_signal_processor.vfo_freq[i] = float(dsp_settings.get("vfo_freq_" + str(i), 0))
-                    web_interface.module_signal_processor.vfo_squelch_mode[i] = dsp_settings.get(
-                        "vfo_squelch_mode_" + str(i), "Default"
-                    )
-                    web_interface.module_signal_processor.vfo_squelch[i] = int(
-                        dsp_settings.get("vfo_squelch_" + str(i), 0)
-                    )
-                    web_interface.module_signal_processor.vfo_demod[i] = dsp_settings.get(
-                        "vfo_demod_" + str(i), "Default"
-                    )
-                    web_interface.module_signal_processor.vfo_iq[i] = dsp_settings.get("vfo_iq_" + str(i), "Default")
-
-                web_interface.module_signal_processor.DOA_algorithm = dsp_settings.get("doa_method", "MUSIC")
-                web_interface.module_signal_processor.DOA_expected_num_of_sources = dsp_settings.get(
-                    "expected_num_of_sources", 1
-                )
-                web_interface._doa_fig_type = dsp_settings.get("doa_fig_type", "Linear")
-                web_interface.module_signal_processor.doa_measure = web_interface._doa_fig_type
-                web_interface.module_signal_processor.ula_direction = dsp_settings.get("ula_direction", "Both")
-                web_interface.module_signal_processor.array_offset = int(dsp_settings.get("array_offset", 0))
-
-                freq_delta = web_interface.daq_center_freq - center_freq
-                gain_delta = web_interface.module_receiver.daq_rx_gain - gain
-
-                if abs(freq_delta) > 0.001 or abs(gain_delta) > 0.001:
-                    web_interface.daq_center_freq = center_freq
-                    web_interface.config_daq_rf(center_freq, gain)
-                    for i in range(web_interface.module_signal_processor.max_vfos):
-                        half_band_width = (web_interface.module_signal_processor.vfo_bw[i] / 10**6) / 2
-                        min_freq = web_interface.daq_center_freq - web_interface.daq_fs / 2 + half_band_width
-                        max_freq = web_interface.daq_center_freq + web_interface.daq_fs / 2 - half_band_width
-                        if min_freq > (web_interface.module_signal_processor.vfo_freq[i] / 10**6) or max_freq < (
-                            web_interface.module_signal_processor.vfo_freq[i] / 10**6
-                        ):
-                            web_interface.module_signal_processor.vfo_freq[i] = (
-                                web_interface.module_receiver.daq_center_freq
-                            )
-
-                    wavelength = 300 / web_interface.daq_center_freq
-
-                    if web_interface.module_signal_processor.DOA_ant_alignment == "UCA":
-                        # Convert RADIUS to INTERELEMENT SPACING
-                        inter_elem_spacing = (
-                            np.sqrt(2)
-                            * web_interface.ant_spacing_meters
-                            * np.sqrt(
-                                1 - np.cos(np.deg2rad(360 / web_interface.module_signal_processor.channel_number))
-                            )
-                        )
-                        web_interface.module_signal_processor.DOA_inter_elem_space = inter_elem_spacing / wavelength
-                    else:
-                        web_interface.module_signal_processor.DOA_inter_elem_space = (
-                            web_interface.ant_spacing_meters / wavelength
-                        )
+                apply_settings_dict(web_interface, dsp_settings)
 
                 if dsp_settings.get("ext_upd_flag", False):
                     web_interface.needs_refresh = True

--- a/_ui/_web_interface/utils.py
+++ b/_ui/_web_interface/utils.py
@@ -26,6 +26,20 @@ from variables import (
 RED_COLOR = {"color": "#e74c3c"}
 
 
+def _safe_push(app, mods: dict) -> None:
+    """Call app.push_mods() and silently swallow the 'before run_server' race.
+
+    On slow hardware (Pi 4) the 3-second startup timer in app.py can fire
+    before dash_devices has finished its run_server() setup.  Rather than
+    crashing the timer thread, we skip the push — the next timer tick (10 ms
+    for fetch_dsp_data, 1 s for fetch_gps_data) will retry successfully.
+    """
+    try:
+        app.push_mods(mods)
+    except Exception:
+        pass
+
+
 def read_config_file_dict(config_fname=daq_config_filename):
     parser = ConfigParser()
     found = parser.read([config_fname])
@@ -220,11 +234,7 @@ def fetch_dsp_data(app, web_interface, spectrum_fig, waterfall_fig):
                 web_interface.squelch_update = data_entry[1].copy()
             elif data_entry[0] == "VFO-0 Frequency":
                 if app is not None:
-                    app.push_mods(
-                        {
-                            "vfo_0_freq": {"value": data_entry[1] * HZ_TO_MHZ},
-                        }
-                    )
+                    _safe_push(app, {"vfo_0_freq": {"value": data_entry[1] * HZ_TO_MHZ}})
             else:
                 web_interface.logger.warning("Unknown data entry: {:s}".format(data_entry[0]))
     except queue.Empty:
@@ -252,13 +262,11 @@ def fetch_dsp_data(app, web_interface, spectrum_fig, waterfall_fig):
 
 def fetch_gps_data(app, web_interface):
     if app is not None:
-        app.push_mods(
-            {
-                "body_gps_latitude": {"children": web_interface.module_signal_processor.latitude},
-                "body_gps_longitude": {"children": web_interface.module_signal_processor.longitude},
-                "body_gps_heading": {"children": web_interface.module_signal_processor.heading},
-            }
-        )
+        _safe_push(app, {
+            "body_gps_latitude": {"children": web_interface.module_signal_processor.latitude},
+            "body_gps_longitude": {"children": web_interface.module_signal_processor.longitude},
+            "body_gps_heading": {"children": web_interface.module_signal_processor.heading},
+        })
 
     web_interface.gps_timer = Timer(1, fetch_gps_data, args=(app, web_interface))
     web_interface.gps_timer.start()
@@ -552,46 +560,42 @@ def update_daq_status(app, web_interface):
         gps_en_str = web_interface.module_signal_processor.gps_status
         gps_en_str_style = {"color": "#e74c3c"}
 
-    app.push_mods(
-        {
-            "body_daq_update_rate": {"children": daq_update_rate_str},
-            "body_daq_dsp_latency": {"children": daq_dsp_latency},
-            "body_daq_frame_index": {"children": daq_frame_index_str},
-            "body_daq_frame_sync": {"children": daq_frame_sync_str},
-            "body_daq_frame_type": {"children": daq_frame_type_str},
-            "body_daq_power_level": {"children": daq_power_level_str},
-            "body_daq_conn_status": {"children": daq_conn_status_str},
-            "body_daq_delay_sync": {"children": daq_delay_sync_str},
-            "body_daq_iq_sync": {"children": daq_iq_sync_str},
-            "body_daq_noise_source": {"children": daq_noise_source_str},
-            "body_daq_rf_center_freq": {"children": daq_rf_center_freq_str},
-            "body_daq_sampling_freq": {"children": daq_sampling_freq_str},
-            "body_dsp_decimated_bw": {"children": dsp_decimated_bw_str},
-            "body_vfo_range": {"children": vfo_range_str},
-            "body_daq_cpi": {"children": daq_cpi_str},
-            "body_daq_if_gain": {"children": web_interface.daq_if_gains},
-            "body_max_amp": {"children": daq_max_amp_str},
-            "body_avg_powers": {"children": daq_avg_powers_str},
-            "gps_status": {"children": gps_en_str},
-        }
-    )
+    _safe_push(app, {
+        "body_daq_update_rate": {"children": daq_update_rate_str},
+        "body_daq_dsp_latency": {"children": daq_dsp_latency},
+        "body_daq_frame_index": {"children": daq_frame_index_str},
+        "body_daq_frame_sync": {"children": daq_frame_sync_str},
+        "body_daq_frame_type": {"children": daq_frame_type_str},
+        "body_daq_power_level": {"children": daq_power_level_str},
+        "body_daq_conn_status": {"children": daq_conn_status_str},
+        "body_daq_delay_sync": {"children": daq_delay_sync_str},
+        "body_daq_iq_sync": {"children": daq_iq_sync_str},
+        "body_daq_noise_source": {"children": daq_noise_source_str},
+        "body_daq_rf_center_freq": {"children": daq_rf_center_freq_str},
+        "body_daq_sampling_freq": {"children": daq_sampling_freq_str},
+        "body_dsp_decimated_bw": {"children": dsp_decimated_bw_str},
+        "body_vfo_range": {"children": vfo_range_str},
+        "body_daq_cpi": {"children": daq_cpi_str},
+        "body_daq_if_gain": {"children": web_interface.daq_if_gains},
+        "body_max_amp": {"children": daq_max_amp_str},
+        "body_avg_powers": {"children": daq_avg_powers_str},
+        "gps_status": {"children": gps_en_str},
+    })
 
-    app.push_mods(
-        {
-            "body_daq_frame_sync": {"style": frame_sync_style},
-            "body_daq_frame_type": {"style": frame_type_style},
-            "body_daq_power_level": {"style": daq_power_level_style},
-            "body_daq_conn_status": {"style": conn_status_style},
-            "body_daq_delay_sync": {"style": delay_sync_style},
-            "body_daq_iq_sync": {"style": iq_sync_style},
-            "body_daq_noise_source": {"style": noise_source_style},
-            "gps_status": {"style": gps_en_str_style},
-        }
-    )
+    _safe_push(app, {
+        "body_daq_frame_sync": {"style": frame_sync_style},
+        "body_daq_frame_type": {"style": frame_type_style},
+        "body_daq_power_level": {"style": daq_power_level_style},
+        "body_daq_conn_status": {"style": conn_status_style},
+        "body_daq_delay_sync": {"style": delay_sync_style},
+        "body_daq_iq_sync": {"style": iq_sync_style},
+        "body_daq_noise_source": {"style": noise_source_style},
+        "gps_status": {"style": gps_en_str_style},
+    })
 
     # Update local recording file size
     recording_file_size = web_interface.module_signal_processor.get_recording_filesize()
-    app.push_mods({"body_file_size": {"children": recording_file_size}})
+    _safe_push(app, {"body_file_size": {"children": recording_file_size}})
 
 
 def get_agc_warning_style_from_gain(gain):

--- a/_ui/_web_interface/utils.py
+++ b/_ui/_web_interface/utils.py
@@ -2,6 +2,7 @@ import copy
 import json
 import os
 import queue
+import time
 from configparser import ConfigParser
 from math import inf
 from threading import Timer
@@ -179,6 +180,24 @@ def fetch_dsp_data(app, web_interface, spectrum_fig, waterfall_fig):
                 web_interface.logger.debug("Spectrum data fetched from signal processing que")
                 spectrum_update_flag = 1
                 web_interface.spectrum = data_entry[1]
+                # WebSocket broadcast — always fires, not gated on the Dash UI page
+                try:
+                    import kraken_ws_server as _ws
+                    M = web_interface.module_receiver.M
+                    freq_axis = (
+                        web_interface.spectrum[0, :] + web_interface.daq_center_freq * 10**6
+                    ).tolist()
+                    channels = {
+                        f"ch{m}": web_interface.spectrum[m + 1, :].tolist() for m in range(M)
+                    }
+                    _ws.broadcast_from_thread({
+                        "type": "spectrum",
+                        "timestamp": int(time.time() * 1000),
+                        "freq_axis": freq_axis,
+                        "channels": channels,
+                    })
+                except Exception:
+                    pass
             elif data_entry[0] == "doa_thetas":
                 web_interface.doa_thetas = data_entry[1]
                 doa_update_flag = 1

--- a/gui_run.sh
+++ b/gui_run.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+#
+# Usage:
+#   ./gui_run.sh            — start with full web GUI on port 8080
+#   ./gui_run.sh --headless — start without GUI; control via WebSocket on 8082
 
 IPADDR="0.0.0.0"
 IPPORT="8081"
@@ -9,29 +13,24 @@ SHARED_FOLDER_DAQ_LOGS="${SHARED_FOLDER}/logs/heimdall_daq_fw"
 
 SETTINGS_PATH="${SHARED_FOLDER}/settings.json"
 
-declare -A STATE_TO_MESSAGE=(["true"]="ENABLED" ["false"]="DISABLED")
-REMOTE_CONTROL="false"
-SERVER_BIN="sudo php -S ${IPADDR}:${IPPORT} -t"
-if [ -f "${SETTINGS_PATH}" ] && [ -x "$(command -v miniserve)" ] && [ -x "$(command -v jq)" ]; then
-    REMOTE_CONTROL=$(jq .en_remote_control ${SETTINGS_PATH})
-    if [ "$REMOTE_CONTROL" = "true" ]; then
-        SERVER_BIN="miniserve -i ${IPADDR} -p ${IPPORT} -P -u -o"
+# Parse --headless flag
+HEADLESS=false
+for arg in "$@"; do
+    if [ "$arg" = "--headless" ]; then
+        HEADLESS=true
     fi
-fi
-echo
-echo "Remote Control is ${STATE_TO_MESSAGE[$REMOTE_CONTROL]}"
-if [ $REMOTE_CONTROL = "false" ]; then
-    echo "To enable Remote Control please install miniserve and jq."
-    echo "Then change 'en_remote_control' setting in ${SETTINGS_PATH} file to 'true'."
-    echo "Finally, apply settings by restarting the software."
-fi
-echo
+done
 
 echo "Starting KrakenSDR Direction Finder"
+if [ "$HEADLESS" = true ]; then
+    echo "Mode: HEADLESS (no GUI — WebSocket only on $IPADDR:8082)"
+else
+    echo "Mode: GUI (web interface on $IPADDR:8080, WebSocket on $IPADDR:8082)"
+fi
+echo
 
-# Create folder, if it does not exists, that will contain data shared with clients
+# Create shared folders
 mkdir -p "${SHARED_FOLDER}"
-# Create folder, if it does not exists, that will contain logs shared with clients
 mkdir -p "${SHARED_FOLDER_DOA_LOGS}"
 mkdir -p "${SHARED_FOLDER_DAQ_LOGS}"
 
@@ -42,14 +41,35 @@ sleep 0.1
 # Start rsync to sync DAQ logs into shared folder
 ./util/sync_daq_logs.sh >/dev/null 2>/dev/null &
 
-echo "Web Interface Running at $IPADDR:8080"
-python3 _ui/_web_interface/app.py >"${SHARED_FOLDER_DOA_LOGS}/ui.log" 2>&1 &
+if [ "$HEADLESS" = true ]; then
+    # Headless: no Dash GUI, no 8081 file server — WS on 8082 is the sole interface
+    echo "WebSocket server will be available at ws://$IPADDR:8082/ws/kraken"
+    python3 _ui/_web_interface/headless.py >"${SHARED_FOLDER_DOA_LOGS}/ui.log" 2>&1 &
+else
+    declare -A STATE_TO_MESSAGE=(["true"]="ENABLED" ["false"]="DISABLED")
+    REMOTE_CONTROL="false"
+    SERVER_BIN="sudo php -S ${IPADDR}:${IPPORT} -t"
+    if [ -f "${SETTINGS_PATH}" ] && [ -x "$(command -v miniserve)" ] && [ -x "$(command -v jq)" ]; then
+        REMOTE_CONTROL=$(jq .en_remote_control ${SETTINGS_PATH})
+        if [ "$REMOTE_CONTROL" = "true" ]; then
+            SERVER_BIN="miniserve -i ${IPADDR} -p ${IPPORT} -P -u -o"
+        fi
+    fi
+    echo "Remote Control (8081) is ${STATE_TO_MESSAGE[$REMOTE_CONTROL]}"
+    if [ "$REMOTE_CONTROL" = "false" ]; then
+        echo "To enable Remote Control please install miniserve and jq."
+        echo "Then change 'en_remote_control' in ${SETTINGS_PATH} to 'true'."
+        echo "Finally, apply settings by restarting the software."
+    fi
+    echo
 
-# Start webserver to share output and settings with clients
-echo "Data Out Server Running at $IPADDR:$IPPORT"
-# $SERVER_BIN "${SHARED_FOLDER}" 2> server.log &
-# $SERVER_BIN "${SHARED_FOLDER}" 2>/dev/null &
-$SERVER_BIN "${SHARED_FOLDER}" >/miniserve_error.log 2>&1  &
+    echo "Web Interface Running at $IPADDR:8080"
+    python3 _ui/_web_interface/app.py >"${SHARED_FOLDER_DOA_LOGS}/ui.log" 2>&1 &
+
+    # Start webserver to share output and settings with clients
+    echo "Data Out Server Running at $IPADDR:$IPPORT"
+    $SERVER_BIN "${SHARED_FOLDER}" >/miniserve_error.log 2>&1 &
+fi
 
 # Start nodejs server for KrakenSDR Pro App
 #node _nodejs/index.js 1>/dev/null 2>/dev/null &

--- a/gui_run.sh
+++ b/gui_run.sh
@@ -49,6 +49,7 @@ python3 _ui/_web_interface/app.py >"${SHARED_FOLDER_DOA_LOGS}/ui.log" 2>&1 &
 echo "Data Out Server Running at $IPADDR:$IPPORT"
 # $SERVER_BIN "${SHARED_FOLDER}" 2> server.log &
 # $SERVER_BIN "${SHARED_FOLDER}" 2>/dev/null &
+$SERVER_BIN "${SHARED_FOLDER}" >/miniserve_error.log 2>&1  &
 
 # Start nodejs server for KrakenSDR Pro App
 #node _nodejs/index.js 1>/dev/null 2>/dev/null &

--- a/gui_run.sh
+++ b/gui_run.sh
@@ -48,7 +48,7 @@ python3 _ui/_web_interface/app.py >"${SHARED_FOLDER_DOA_LOGS}/ui.log" 2>&1 &
 # Start webserver to share output and settings with clients
 echo "Data Out Server Running at $IPADDR:$IPPORT"
 # $SERVER_BIN "${SHARED_FOLDER}" 2> server.log &
-$SERVER_BIN "${SHARED_FOLDER}" 2>/dev/null &
+# $SERVER_BIN "${SHARED_FOLDER}" 2>/dev/null &
 
 # Start nodejs server for KrakenSDR Pro App
 #node _nodejs/index.js 1>/dev/null 2>/dev/null &


### PR DESCRIPTION
This pull request modifies the original kraken_doa software to have the following capabilities:
- Headless Application so specific pages in the GUI are no longer required to be open in order to update certain parameters of the Kraken 
- Introduction of a Web Socket (ws://<host>:8082/ws/kraken) functioning as a bi-directional API over a persistent connection rather than the traditional request/response pattern of a REST API.
- starts to eliminate the need for a miniconda server established in the original code (running on 8081). 